### PR TITLE
Add structural card subcomponents

### DIFF
--- a/frontend/src/components/universal/Card/index.tsx
+++ b/frontend/src/components/universal/Card/index.tsx
@@ -1,6 +1,10 @@
 import * as React from 'react';
 import styled  from 'styled-components';
 
+import CardImage from 'components/CardImage';
+import CardTitle from 'components/CardTitle';
+import CardDescription from 'components/CardDescription';
+
 const Wrapper = styled.div`
   padding: 1.2vw;
   margin: 1vw;
@@ -11,8 +15,18 @@ const Wrapper = styled.div`
   color: ${(props) => props.theme.colors.accent};
 `;
 
+const CardImageCell = styled.td`
+  padding-top: 0;
+`;
+
+const CardTitleCell = styled.td`
+  padding-top: 0;
+`;
+
 export interface CardProps {
-    children: React.ReactNode;
+    title: string;
+    description?: string;
+    image?: string;
 }
 
 export default class Card extends React.Component<CardProps, undefined> {
@@ -20,7 +34,33 @@ export default class Card extends React.Component<CardProps, undefined> {
     render() {
         return (
             <Wrapper>
-                {this.props.children}
+                <table>
+                    <tbody>
+                        <tr>
+                            {
+                                (!this.props.image)?(null):(
+                                    <CardImageCell>
+                                        <CardImage src={this.props.image} />
+                                    </CardImageCell>
+                                )
+                            }
+                            <CardTitleCell>
+                                <CardTitle>
+                                    {this.props.title}
+                                </CardTitle>
+                            </CardTitleCell>
+                        </tr>
+                    </tbody>
+                </table>
+                {
+                    (!this.props.description)?(null):(
+                        <div>
+                            <CardDescription>
+                                {this.props.description}
+                            </CardDescription>
+                        </div>
+                    )
+                }
             </Wrapper>
         );
     }

--- a/frontend/src/components/universal/Card/index.tsx
+++ b/frontend/src/components/universal/Card/index.tsx
@@ -15,12 +15,16 @@ const Wrapper = styled.div`
   color: ${(props) => props.theme.colors.accent};
 `;
 
-const CardImageCell = styled.td`
-  padding-top: 0;
+const ContentRow = styled.div`
+ display: flex;
 `;
 
-const CardTitleCell = styled.td`
-  padding-top: 0;
+const CardImageWrapper = styled.div`
+  flex: 50%;
+`;
+
+const CardTitleWrapper = styled.div`
+  flex: 50%;
 `;
 
 export interface CardProps {
@@ -34,33 +38,31 @@ export default class Card extends React.Component<CardProps, undefined> {
     render() {
         return (
             <Wrapper>
-                <table>
-                    <tbody>
-                        <tr>
-                            {
-                                (!this.props.image)?(null):(
-                                    <CardImageCell>
-                                        <CardImage src={this.props.image} />
-                                    </CardImageCell>
-                                )
-                            }
-                            <CardTitleCell>
-                                <CardTitle>
-                                    {this.props.title}
-                                </CardTitle>
-                            </CardTitleCell>
-                        </tr>
-                    </tbody>
-                </table>
-                {
-                    (!this.props.description)?(null):(
-                        <div>
-                            <CardDescription>
-                                {this.props.description}
-                            </CardDescription>
-                        </div>
-                    )
-                }
+                <ContentRow>
+                    {
+                        (!this.props.image)?(null):(
+                            <CardImageWrapper>
+                                <CardImage src={this.props.image} />
+                            </CardImageWrapper>
+                        )
+                    }
+                    <CardTitleWrapper>
+                        <CardTitle>
+                            {this.props.title}
+                        </CardTitle>
+                    </CardTitleWrapper>
+                </ContentRow>
+                <ContentRow>
+                    {
+                        (!this.props.description)?(null):(
+                            <div>
+                                <CardDescription>
+                                    {this.props.description}
+                                </CardDescription>
+                            </div>
+                        )
+                    }
+                </ContentRow>
             </Wrapper>
         );
     }

--- a/frontend/src/components/universal/CardDescription/index.tsx
+++ b/frontend/src/components/universal/CardDescription/index.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react';
+import styled  from 'styled-components';
+
+interface WrapperProps {
+  fontSize?: string;
+  theme?: any;
+};
+
+const Wrapper = styled.div`
+  font-family: ${(props: WrapperProps) => props.theme.primaryFont};
+  color: ${(props: WrapperProps) => props.theme.colors.accent};
+  font-family: ${(props: WrapperProps) => props.theme.primaryFont};
+  font-size: ${(props: WrapperProps) => props.theme.fontSize[props.fontSize || 'default']};
+`;
+
+export interface CardDescriptionProps {
+    children: string;
+};
+
+export default class CardDescription extends React.Component<CardDescriptionProps, undefined> {
+    
+    render() {
+        return (
+            <Wrapper>
+                {this.props.children}
+            </Wrapper>
+        );
+    }
+}

--- a/frontend/src/components/universal/CardImage/index.tsx
+++ b/frontend/src/components/universal/CardImage/index.tsx
@@ -3,11 +3,6 @@ import styled  from 'styled-components';
 
 import Logo, { LogoType } from 'components/Logo';
 
-interface WrapperProps {
-  fontSize?: string;
-  theme?: any;
-};
-
 const Wrapper = styled.div`
   width: 3vw;
   display: inline-block;

--- a/frontend/src/components/universal/CardImage/index.tsx
+++ b/frontend/src/components/universal/CardImage/index.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react';
+import styled  from 'styled-components';
+
+import Logo, { LogoType } from 'components/Logo';
+
+interface WrapperProps {
+  fontSize?: string;
+  theme?: any;
+};
+
+const Wrapper = styled.div`
+  width: 3vw;
+  display: inline-block;
+`;
+
+export interface CardImageProps {
+    src: LogoType | string;
+};
+
+export default class CardImage extends React.Component<CardImageProps, undefined> {
+    
+    render() {
+        return (
+            <Wrapper>
+                <Logo type={this.props.src} />
+            </Wrapper>
+        );
+    }
+}

--- a/frontend/src/components/universal/CardTitle/index.tsx
+++ b/frontend/src/components/universal/CardTitle/index.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react';
+import styled  from 'styled-components';
+
+interface WrapperProps {
+  fontSize?: string;
+  theme?: any;
+};
+
+const Wrapper = styled.div`
+  font-family: ${(props: WrapperProps) => props.theme.primaryFont};
+  color: ${(props: WrapperProps) => props.theme.colors.accent};
+  font-family: ${(props: WrapperProps) => props.theme.primaryFont};
+  font-size: ${(props: WrapperProps) => props.theme.fontSize[props.fontSize || 'XL']};
+`;
+
+export interface CardTitleProps {
+    children: string;
+};
+
+export default class CardTitle extends React.Component<CardTitleProps, undefined> {
+    
+    render() {
+        return (
+            <Wrapper>
+                {this.props.children}
+            </Wrapper>
+        );
+    }
+}

--- a/frontend/src/components/universal/CardTitle/index.tsx
+++ b/frontend/src/components/universal/CardTitle/index.tsx
@@ -6,7 +6,7 @@ interface WrapperProps {
   theme?: any;
 };
 
-const Wrapper = styled.div`
+const Wrapper = styled.div<WrapperProps>`
   font-family: ${(props: WrapperProps) => props.theme.primaryFont};
   color: ${(props: WrapperProps) => props.theme.colors.accent};
   font-family: ${(props: WrapperProps) => props.theme.primaryFont};
@@ -15,13 +15,14 @@ const Wrapper = styled.div`
 
 export interface CardTitleProps {
     children: string;
+    fontSize?: string;
 };
 
 export default class CardTitle extends React.Component<CardTitleProps, undefined> {
     
     render() {
         return (
-            <Wrapper>
+            <Wrapper fontSize={this.props.fontSize}>
                 {this.props.children}
             </Wrapper>
         );


### PR DESCRIPTION
Added subcomponents for cards (in fact cards are visually displayed as one-side bordered boxes).
* title
* description
* image

![image](https://user-images.githubusercontent.com/7319352/50590907-27a7d980-0e8d-11e9-9a76-8f4b5c658d6d.png)
