### PR TITLE
Add data provider

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -77,6 +77,7 @@
     "@types/react-router-dom": "^4.3.1",
     "@types/styled-components": "^4.1.4",
     "axios": "^0.18.0",
+    "moment": "^2.23.0",
     "node-polyglot": "^2.3.0",
     "rc-tooltip": "^3.7.3",
     "react-absolute-grid": "^3.0.1",

--- a/frontend/src/components/universal/DataProvider/DataTypePresets.ts
+++ b/frontend/src/components/universal/DataProvider/DataTypePresets.ts
@@ -1,0 +1,57 @@
+import * as moment from 'moment';
+import { addPrePostfixFormatAxis, addPrePostfixFormatCursor } from './index';
+
+export default {
+    'number': (typeOptions, type, point, options) => {
+        const parseData = (point, options) => {
+            return parseInt(point.value) || null;
+        };
+        
+        const formatAxis = (point, options) => {
+            return addPrePostfixFormatAxis(typeOptions, point, options, (point.value)?('' + point.value):(''));
+        };
+        
+        const formatCursor = (point, options) => {
+            return addPrePostfixFormatCursor(typeOptions, point, options, (point.value)?('' + point.value):(''));
+        };
+        
+        return {
+            parseInputData: parseData,
+            parseOutputData: parseData,
+            formatInputAxis:  formatAxis,
+            formatOutputAxis: formatAxis,
+            formatInputCursor: formatCursor,
+            formatOutputCursor: formatCursor
+        };
+    },
+    'date': (typeOptions, type, point, options) => {
+        
+        const parseData = (point, options) => {
+            const format = typeOptions.parseFormat || typeOptions.format;
+            return (format)?(moment(point.value, format).toString()):(moment(point.value).toString());
+        };
+        
+        const formatAxis = (point, options) => {
+            const format = typeOptions.axisFormat || typeOptions.displayFormat || typeOptions.format;
+            return addPrePostfixFormatAxis(typeOptions, point, options,
+                (format)?(moment(point.value).format(format)):(moment(point.value).format())
+            );
+        };
+        
+        const formatCursor = (point, options) => {
+            const format = typeOptions.cursorFormat || typeOptions.displayFormat || typeOptions.format;
+            return addPrePostfixFormatCursor(typeOptions, point, options,
+                (format)?(moment(point.value).format(format)):(moment(point.value).format())
+            );
+        };
+        
+        return {
+            parseInputData: parseData,
+            parseOutputData: parseData,
+            formatInputAxis:  formatAxis,
+            formatOutputAxis: formatAxis,
+            formatInputCursor: formatCursor,
+            formatOutputCursor: formatCursor
+        };  
+    }
+};

--- a/frontend/src/components/universal/DataProvider/index.tsx
+++ b/frontend/src/components/universal/DataProvider/index.tsx
@@ -1,0 +1,285 @@
+import * as React from 'react';
+
+import DATA_TYPE_PRESETS from './DataTypePresets';
+
+
+export interface DataProviderProps {
+    data: any;
+    children?: Array<React.ReactElement<any>> | React.ReactElement<any>;
+};
+
+export interface ColumnSpecs {
+    name: string;
+    field?: string;
+};
+
+export type RowSpecs = any;
+
+export interface DataFormat {
+    rows: Array<RowSpecs>;
+    columns: Array<ColumnSpecs>;
+};
+
+interface DataProviderState {
+    data: DataFormat;
+};
+
+const DataProviderContext = React.createContext(null);
+
+export interface DataConsumerProps {
+    children: Array<React.ReactElement<any>>;
+    data?: DataFormat;
+    onDataChanged?: (data: DataFormat) => void;
+};
+
+export interface FormatedDataPoint {
+    value: any;
+};
+
+export interface DataPoint {
+    value: any;
+};
+
+export interface DataFormatOptions {
+    input?: any | string | Array<string>;
+    output?: any | string | Array<string>;
+    parseInputData?: (point: DataPoint, options: DataFormatOptions) => any;
+    parseOutputData?: (point: DataPoint, options: DataFormatOptions) => any;
+    formatInputAxis?:  (point: DataPoint, options: DataFormatOptions) => any;
+    formatOutputAxis?: (point: DataPoint, options: DataFormatOptions) => any;
+    formatInputCursor?: (point: DataPoint, options: DataFormatOptions) => any;
+    formatOutputCursor?: (point: DataPoint, options: DataFormatOptions) => any;
+}
+
+export function getInputColumn(data: DataFormat, options: DataFormatOptions = {}) {
+    let inputColumn = 'x';
+    if(typeof options.input === 'string') {
+        inputColumn = options.input;
+    }
+    
+    return inputColumn;
+};
+
+export function getOutputColumns(data: DataFormat, options: DataFormatOptions = {}) {
+    let outputColumns = null;
+    if(typeof options.output === 'string') {
+       outputColumns = [ options.output ]; 
+    }
+    
+    if(options.output && options.output.forEach) {
+        outputColumns = options.output;
+    }
+    
+    return outputColumns || [];
+};
+
+
+export const addPrePostfixFormatAxis = (typeOptions, point: DataPoint, options, infix: string) => {
+    return `${typeOptions.axisPrefix || typeOptions.prefix || ''}${infix}${typeOptions.axisPostfix || typeOptions.postfix  || ''}`;
+};
+
+export const addPrePostfixFormatCursor = (typeOptions, data: DataFormat, options, infix) => {
+    return (
+        <span>
+            {typeOptions.cursorPrefix || typeOptions.prefix || ''}
+            {infix}
+            {typeOptions.cursorPostfix || typeOptions.postfix || ''}
+        </span>
+    );
+};
+
+export function getFormatDefaults(type: string, point: DataPoint, data: DataFormat, options: DataFormatOptions = {}): DataFormatOptions {
+    
+    let presetOverrideOptions = {};
+    options = Object.assign({}, options);
+    
+    if(typeof options.input === 'string') {
+        options.input = data.columns.filter((column) => column.field === options.input || column.name === options.input)[0];
+    }
+    
+    if(typeof options.output === 'string') {
+        options.output = data.columns.filter((column) => column.field === options.output || column.name === options.output)[0];
+    }
+    
+    if(options.output && options.output.forEach) {
+        options.output = data.columns.filter((column) => options.output.indexOf(column.field) > -1 || options.output.indexOf(column.name) > -1)[0];
+    }
+    
+    if(!options.input) {
+        options.input = {
+            type: 'number'
+        };
+    }
+    
+    if(!options.output) {
+        options.output = {
+            type: 'number'
+        };
+    }
+    
+    if(options.input && options.input.type && type.indexOf('input:') == 0) {
+        const preset = DATA_TYPE_PRESETS[options.input.type];
+        presetOverrideOptions = Object.assign({}, presetOverrideOptions, preset(options.input, type, point, options));
+    }
+    
+    if(options.output && options.output.type && type.indexOf('output:') == 0) {
+        const preset = DATA_TYPE_PRESETS[options.output.type];
+        presetOverrideOptions = Object.assign({}, presetOverrideOptions, preset(options.output, type, point, options));
+    }
+    
+    return Object.assign(
+        {
+           parseInputData: (point, options) => ('' + point.value),
+           parseOutputData: (point, options) => ('' + point.value),
+           formatInputAxis:  (point, options) => ('' + point.value),
+           formatOutputAxis: (point, options) => ('' + point.value),
+           formatInputCursor: (point, options) => ('' + point.value),
+           formatOutputCursor: (point, options) => ('' + point.value)
+        },
+        presetOverrideOptions,
+        options
+     );
+};
+
+export function formatData(type: string, point: DataPoint, data: DataFormat, options: DataFormatOptions = {}): FormatedDataPoint {
+    
+    options = getFormatDefaults(type, point, data, options);
+    
+    switch(type) {
+        case 'input:parse':
+            return {
+                value: options.parseInputData(point, options)
+            };
+        case 'output:parse':
+            return {
+                value: options.parseOutputData(point, options)
+            };
+        case 'input:axis':
+            return {
+                value: options.formatInputAxis(point, options)
+            };
+        case 'output:axis':
+            return {
+                value: options.formatOutputAxis(point, options)
+            };
+        case 'input:cursor':
+            return {
+                value: options.formatInputCursor(point, options)
+            };
+        case 'output:cursor':
+            return {
+                value: options.formatOutputCursor(point, options)
+            };
+    }
+    
+   return {
+       value: null
+   };
+};
+
+export function applyDataFormaters(data: DataFormat, options: DataFormatOptions = {}, type: string = 'parse'): DataFormat {
+   let filteredColumns = null;
+    if(typeof options.output === 'string') {
+       filteredColumns = [ options.output ]; 
+    }
+    
+    if(options.output && options.output.forEach) {
+        filteredColumns = options.output;
+    }
+        
+    let inputColumn = 'x';
+    if(typeof options.input === 'string') {
+        inputColumn = options.input;
+    }
+        
+    return Object.assign({}, data, {
+        rows: data.rows.map((row) => {
+            let formattedRow = {};
+            
+            formattedRow[inputColumn] = formatData('input:'+type, {
+                value: row[inputColumn]
+            }, data, options).value;
+            
+            filteredColumns.forEach((column) => {
+                formattedRow[column] = formatData('output:'+type, {
+                    value: row[column]
+                }, data, options).value;
+            });
+            
+            return formattedRow;
+        })
+    });
+};
+
+export class DataConsumer extends React.Component<any & DataConsumerProps, undefined> {
+  render() {
+    return (
+        <DataProviderContext.Consumer>
+            {
+                (context) => {
+                    if(!context) {
+                        return this.props.children;
+                    }
+                    
+                    const { data, onDataChanged } = context;
+                    return React.Children.map(this.props.children, (child) =>
+                        React.cloneElement(child as React.ReactElement<any>, {
+                            data: this.props.data || data,
+                            onDataChanged: (this.props.onDataChanged)?((data) => {
+                                this.props.onDataChanged(data);
+                                onDataChanged(data);
+                            }):(onDataChanged)
+                        })
+                    );
+                }
+            }
+        </DataProviderContext.Consumer>
+    );
+  }
+};
+
+export interface WithDataProps {
+    data?: DataFormat;
+};
+
+export function withData<P>(Component: React.ComponentType<P & WithDataProps> | React.SFC<P & WithDataProps>): React.SFC<P> {
+    return (props: P) => {
+        return (
+            <DataConsumer>
+                <Component {...props} />
+            </DataConsumer>
+        );
+    };
+};
+
+export default class DataProvider extends React.Component<DataProviderProps, DataProviderState> {
+    
+    state: DataProviderState;
+    
+    constructor(props) {
+        super(props);
+        
+        this.state = {
+            data: this.props.data
+        };
+        
+        this.handleDataChange = this.handleDataChange.bind(this);
+    }
+    
+    handleDataChange(data: DataFormat) {
+        this.setState({ data });
+    }
+    
+    render() {
+        return (
+            <DataProviderContext.Provider
+                value={{
+                    data: this.state.data,
+                    onDataChanged: this.handleDataChange
+                }}
+            >
+                {this.props.children}
+            </DataProviderContext.Provider>
+        );
+    }
+};

--- a/frontend/src/components/universal/TinyButtons/index.tsx
+++ b/frontend/src/components/universal/TinyButtons/index.tsx
@@ -1,0 +1,111 @@
+import * as React from 'react';
+import styled, { withTheme }  from 'styled-components';
+
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { IconName } from '@fortawesome/fontawesome-svg-core';
+
+import Tooltip from 'components/Tooltip';
+
+const Wrapper = styled.div`
+  padding: 0;
+`;
+
+interface PanelButtonProps {
+  theme?: any;
+  onClick?: () => void;
+  active?: boolean;
+};
+
+const PanelButton = styled.div<PanelButtonProps>`
+  padding: 0.3vw;
+  display: inline-block;
+  margin-left: 0.1vw;
+  margin-right: 0.1vw;
+  color: ${(props: PanelButtonProps) => (props.active)?(props.theme.colors.lightAccent):(props.theme.colors.primary)};
+  background: ${(props: PanelButtonProps) => (props.active)?(props.theme.colors.primary):('transparent')};
+  cursor: pointer;
+  
+  &:hover {
+    color: ${(props: PanelButtonProps) => props.theme.colors.lightAccent};
+    background: ${(props: PanelButtonProps) => props.theme.colors.primary};
+  }
+`;
+
+const IconLabel = styled.span`
+  margin-left: 0.3vw;
+`;
+
+export interface ButtonSpecs {
+    icon: IconName;
+    active?: boolean;
+    onClick?: () => void;
+    text?: string;
+    tooltip?: React.ReactElement<any>;
+};
+
+export interface TinyButtonsProps {
+    children: Array<ButtonSpecs | null>;
+    info?: string | React.ReactElement<any>;
+};
+
+class TinyButtons extends React.Component<TinyButtonsProps, any> {
+
+    render() {
+        let buttons = (this.props.children || []).filter(button => !!button);
+        
+        if(this.props.info) {
+            buttons.push({
+                icon: 'question-circle',
+                tooltip: (
+                    <div>
+                        {this.props.info}
+                    </div>
+                )
+            });
+        }
+        
+        return (
+            <Wrapper>
+                {
+                    buttons.map((button: ButtonSpecs) => {
+                        let contentNode = (
+                            <span>
+                                <FontAwesomeIcon icon={button.icon} />
+                                {
+                                    (button.text)?(
+                                        <IconLabel>
+                                            {button.text}
+                                        </IconLabel>
+                                    ):(null)
+                                }
+                            </span>
+                        );
+        
+                        if(button.tooltip) {
+                            contentNode = (
+                                <Tooltip
+                                    content={button.tooltip}
+                                    clickTrigger
+                                >
+                                    {contentNode}
+                                </Tooltip>
+                            );
+                        }
+        
+                        return (
+                            <PanelButton
+                                onClick={button.onClick}
+                                active={button.active}
+                            >
+                                {contentNode}
+                            </PanelButton>
+                        );
+                    })
+                }
+            </Wrapper>
+               
+        );
+    }
+}
+
+export default TinyButtons;

--- a/frontend/src/components/universal/index.tsx
+++ b/frontend/src/components/universal/index.tsx
@@ -17,6 +17,7 @@ import Breadcrumbs from './Breadcrumbs';
 import SearchableList from './SearchableList';
 import Card from './Card';
 import Tooltip from './Tooltip';
+import DataProvider from './DataProvider';
 
 export default {
     Button,
@@ -37,5 +38,6 @@ export default {
     Breadcrumbs,
     SearchableList,
     Card,
-    Tooltip
+    Tooltip,
+    DataProvider
 };

--- a/frontend/src/components/universal/index.tsx
+++ b/frontend/src/components/universal/index.tsx
@@ -18,6 +18,7 @@ import SearchableList from './SearchableList';
 import Card from './Card';
 import Tooltip from './Tooltip';
 import DataProvider from './DataProvider';
+import TinyButtons from './TinyButtons';
 
 export default {
     Button,
@@ -39,5 +40,6 @@ export default {
     SearchableList,
     Card,
     Tooltip,
-    DataProvider
+    DataProvider,
+    TinyButtons
 };


### PR DESCRIPTION
The data provider is used to provide data to its child components in a standard way along the entire project.

This PR contains the following features:
* Data provider HOC component (using React context)
* Typings for data format
* Functions to parse and format data for cursors/axes etc.
* Data types presets (number - any integer; date - parsed using [moment](https://www.npmjs.com/package/moment))