### PR TITLE
Custom grid renderers

### DIFF
--- a/frontend/src/components/universal/DataGrid/CellRenderer.tsx
+++ b/frontend/src/components/universal/DataGrid/CellRenderer.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import styled from "styled-components";
 
+import { formatData, DataTargetOutput, FormatedDataPoint } from "components/DataProvider";
 import { CellRenderProps } from "./index";
 
 interface CellWrapperProps {
@@ -45,6 +46,12 @@ class CellRenderer extends React.Component<CellRendererProps, undefined> {
     }
 
     render() {
+        const dataCol = this.props.context.data.columns.filter(col => col.name === this.props.colDef.field)[0];
+
+        const formatedData: FormatedDataPoint = formatData(DataTargetOutput.Cell, { value: this.props.value }, this.props.context.data, {
+            output: dataCol.name,
+        });
+
         return (
             <CellWrapper
                 onMouseOver={this.handleMouseEnter}
@@ -53,7 +60,7 @@ class CellRenderer extends React.Component<CellRendererProps, undefined> {
                 theme={this.props.context.theme}
             >
                 {
-                    (this.props.context.renderCell) ? (this.props.context.renderCell(this.props)) :(this.props.value)
+                    (this.props.context.renderCell) ? (this.props.context.renderCell(this.props, formatedData)) :(formatedData)
                 }
             </CellWrapper>
         );

--- a/frontend/src/components/universal/DataGrid/CellRenderer.tsx
+++ b/frontend/src/components/universal/DataGrid/CellRenderer.tsx
@@ -46,10 +46,9 @@ class CellRenderer extends React.Component<CellRendererProps, undefined> {
     }
 
     render() {
-        const dataCol = this.props.context.data.columns.filter(col => col.name === this.props.colDef.field)[0];
 
         const formatedData: FormatedDataPoint = formatData(DataTargetOutput.Cell, { value: this.props.value }, this.props.context.data, {
-            output: dataCol.name,
+            output: this.props.colDef.field,
         });
 
         return (

--- a/frontend/src/components/universal/DataGrid/CellRenderer.tsx
+++ b/frontend/src/components/universal/DataGrid/CellRenderer.tsx
@@ -60,7 +60,7 @@ class CellRenderer extends React.Component<CellRendererProps, undefined> {
                 theme={this.props.context.theme}
             >
                 {
-                    (this.props.context.renderCell) ? (this.props.context.renderCell(this.props, formatedData)) :(formatedData)
+                    (this.props.context.renderCell) ? (this.props.context.renderCell(this.props, formatedData)) :(formatedData.value)
                 }
             </CellWrapper>
         );

--- a/frontend/src/components/universal/DataGrid/index.tsx
+++ b/frontend/src/components/universal/DataGrid/index.tsx
@@ -4,7 +4,7 @@ import styled, { withTheme } from "styled-components";
 import { Column, ColumnApi, ColDef, GridApi, RowNode } from "ag-grid-community";
 import { AgGridReact } from "ag-grid-react";
 
-import { withData, DataFormat, RowSpecs } from "components/DataProvider";
+import { withData, DataFormat, FormatedDataPoint, RowSpecs } from "components/DataProvider";
 
 import "ag-grid-community/dist/styles/ag-grid.css";
 import "ag-grid-community/dist/styles/ag-theme-balham.css";
@@ -59,10 +59,11 @@ export interface DataGridProps {
 
 export interface DataGridContext {
     theme: any;
+    data: DataFormat;
     enableHoverMode: boolean;
     onRowHovered: (api: GridApi, rowIndex: number, row: RowNode) => void;
     onRowUnhovered: (api: GridApi, rowIndex: number, row: RowNode) => void;
-    renderCell?: (props: CellRenderProps) => React.ReactElement<any>;
+    renderCell?: (props: CellRenderProps, formattedValue: FormatedDataPoint) => React.ReactElement<any>;
 }
 
 export interface AgGridDataFormat {
@@ -138,6 +139,7 @@ class DataGrid extends React.Component<DataGridProps, undefined> {
             onRowHovered: this.handleRowHovered,
             onRowUnhovered: this.handleRowUnhovered,
             renderCell: this.props.renderCell,
+            data: this.props.data,
         };
 
         const { columnDefs, rowData } = this.extractAgGridDataFormat(this.props.data);

--- a/frontend/src/components/universal/DataProvider/DataTypePresets.ts
+++ b/frontend/src/components/universal/DataProvider/DataTypePresets.ts
@@ -1,6 +1,29 @@
 import * as moment from "moment";
 import { addPrePostfixFormatAxis, addPrePostfixFormatCursor, PresetsMap } from "./index";
 
+const numberParseData = (point, options) => {
+    return parseInt(point.value) || null;
+};
+
+const numberFormatAxis = (typeOptions) => ((point, options) => {
+    return addPrePostfixFormatAxis(typeOptions, point, options, (point.value) ? ("" + point.value) :(""));
+});
+
+const numberFormatCursor = (typeOptions) => ((point, options) => {
+    return addPrePostfixFormatCursor(typeOptions, point, options, (point.value) ? ("" + point.value) :(""));
+});
+
+const defaultNumberParsers = (typeOptions) => ({
+    parseInputData: numberParseData,
+    parseOutputData: numberParseData,
+    formatInputAxis:  numberFormatAxis(typeOptions),
+    formatOutputAxis: numberFormatAxis(typeOptions),
+    formatInputCursor: numberFormatCursor(typeOptions),
+    formatOutputCursor: numberFormatCursor(typeOptions),
+    formatInputCell: numberParseData,
+    formatOutputCell: numberParseData,
+});
+
 const PRESETS: PresetsMap = {
     "string": (typeOptions, type, point, options) => {
         const idFun = (point, options) => ("" + point.value);
@@ -16,30 +39,7 @@ const PRESETS: PresetsMap = {
             formatOutputCell: idFun,
         };
     },
-    "number": (typeOptions, type, point, options) => {
-        const parseData = (point, options) => {
-            return parseInt(point.value) || null;
-        };
-
-        const formatAxis = (point, options) => {
-            return addPrePostfixFormatAxis(typeOptions, point, options, (point.value) ? ("" + point.value) :(""));
-        };
-
-        const formatCursor = (point, options) => {
-            return addPrePostfixFormatCursor(typeOptions, point, options, (point.value) ? ("" + point.value) :(""));
-        };
-
-        return {
-            parseInputData: parseData,
-            parseOutputData: parseData,
-            formatInputAxis:  formatAxis,
-            formatOutputAxis: formatAxis,
-            formatInputCursor: formatCursor,
-            formatOutputCursor: formatCursor,
-            formatInputCell: parseData,
-            formatOutputCell: parseData,
-        };
-    },
+    "number": (typeOptions, type, point, options) => defaultNumberParsers(typeOptions),
     "currency": (typeOptions, type, point, options) => {
         const parseData = (point, options) => {
             return parseInt((point.value + "").replace(/\$/, "")) || null;
@@ -49,21 +49,10 @@ const PRESETS: PresetsMap = {
             return `\$${point.value}`;
         };
 
-        const formatAxis = (point, options) => {
-            return addPrePostfixFormatAxis(typeOptions, point, options, (point.value) ? ("" + point.value) :(""));
-        };
-
-        const formatCursor = (point, options) => {
-            return addPrePostfixFormatCursor(typeOptions, point, options, (point.value) ? ("" + point.value) :(""));
-        };
-
         return {
+            ...(defaultNumberParsers(typeOptions)),
             parseInputData: parseData,
             parseOutputData: formatData,
-            formatInputAxis:  formatAxis,
-            formatOutputAxis: formatAxis,
-            formatInputCursor: formatCursor,
-            formatOutputCursor: formatCursor,
             formatInputCell: parseData,
             formatOutputCell: formatData,
         };

--- a/frontend/src/components/universal/DataProvider/DataTypePresets.ts
+++ b/frontend/src/components/universal/DataProvider/DataTypePresets.ts
@@ -1,7 +1,21 @@
 import * as moment from "moment";
-import { addPrePostfixFormatAxis, addPrePostfixFormatCursor } from "./index";
+import { addPrePostfixFormatAxis, addPrePostfixFormatCursor, PresetsMap } from "./index";
 
-export default {
+const PRESETS: PresetsMap = {
+    "string": (typeOptions, type, point, options) => {
+        const idFun = (point, options) => ("" + point.value);
+
+        return {
+            parseInputData: idFun,
+            parseOutputData: idFun,
+            formatInputAxis:  idFun,
+            formatOutputAxis: idFun,
+            formatInputCursor: idFun,
+            formatOutputCursor: idFun,
+            formatInputCell: idFun,
+            formatOutputCell: idFun,
+        };
+    },
     "number": (typeOptions, type, point, options) => {
         const parseData = (point, options) => {
             return parseInt(point.value) || null;
@@ -22,6 +36,36 @@ export default {
             formatOutputAxis: formatAxis,
             formatInputCursor: formatCursor,
             formatOutputCursor: formatCursor,
+            formatInputCell: parseData,
+            formatOutputCell: parseData,
+        };
+    },
+    "currency": (typeOptions, type, point, options) => {
+        const parseData = (point, options) => {
+            return parseInt((point.value + "").replace(/\$/, "")) || null;
+        };
+
+        const formatData = (point, options) => {
+            return `\$${point.value}`;
+        };
+
+        const formatAxis = (point, options) => {
+            return addPrePostfixFormatAxis(typeOptions, point, options, (point.value) ? ("" + point.value) :(""));
+        };
+
+        const formatCursor = (point, options) => {
+            return addPrePostfixFormatCursor(typeOptions, point, options, (point.value) ? ("" + point.value) :(""));
+        };
+
+        return {
+            parseInputData: parseData,
+            parseOutputData: formatData,
+            formatInputAxis:  formatAxis,
+            formatOutputAxis: formatAxis,
+            formatInputCursor: formatCursor,
+            formatOutputCursor: formatCursor,
+            formatInputCell: parseData,
+            formatOutputCell: formatData,
         };
     },
     "date": (typeOptions, type, point, options) => {
@@ -52,6 +96,10 @@ export default {
             formatOutputAxis: formatAxis,
             formatInputCursor: formatCursor,
             formatOutputCursor: formatCursor,
+            formatInputCell: parseData,
+            formatOutputCell: parseData,
         };
     },
 };
+
+export default PRESETS;

--- a/frontend/src/components/universal/DataProvider/DataTypePresets.ts
+++ b/frontend/src/components/universal/DataProvider/DataTypePresets.ts
@@ -42,7 +42,7 @@ const PRESETS: PresetsMap = {
     "number": (typeOptions, type, point, options) => defaultNumberParsers(typeOptions),
     "currency": (typeOptions, type, point, options) => {
         const parseData = (point, options) => {
-            return parseInt((point.value + "").replace(/\$/, "")) || null;
+            return parseInt(point.value.toString().replace(/\$/, "")) || null;
         };
 
         const formatData = (point, options) => {


### PR DESCRIPTION
The main features of this PR are presented below.

## Custom cell presets
Data grid renders cell using `formatOutputCell` formatter that can be key of the column spec:
```
columns: [
        {
            name: "name",
            type: "string",
            prefix: "Budget Name: ",
        },
        {
            name: "current",
            type: "currency",
        },
        {
            name: "budgeted",
            type: "currency",
        },
        {
            name: "forecasted",
            type: "currency",
            formatOutputCell: "ui-line",
        },
        {
            name: "currentVsBudgeted",
            type: "number",
            outputFormatter: (value) => `${value} LOL`,
        },
    ]
```

The formatter can be string (string is the name of other prestet whose formatter is used) or a function that renders cell value.

This feature adds ability to easily introduce custom renderers inside data for `DataProvider`.
