### PR TITLE
Add grid sorting

### DIFF
--- a/frontend/src/components/universal/DataGrid/index.tsx
+++ b/frontend/src/components/universal/DataGrid/index.tsx
@@ -74,6 +74,8 @@ export interface AgGridDataFormat {
 
 class DataGrid extends React.Component<DataGridProps, undefined> {
 
+    api: any;
+
     constructor(props) {
         super(props);
 
@@ -94,7 +96,8 @@ class DataGrid extends React.Component<DataGridProps, undefined> {
         };
     }
 
-    handleRowUnhovered(api: GridApi, rowIndex: number, row: RowNode) {
+    handleRowUnhovered(api: GridApi, visualRowIndex: number, row: RowNode) {
+        const rowIndex = parseInt(row.id);
         if (this.props.onDataChanged) {
             this.props.onDataChanged(
                 this.getDataWithRowsHoveredMarker((row, index, isHovered) => {
@@ -108,7 +111,8 @@ class DataGrid extends React.Component<DataGridProps, undefined> {
         }
     }
 
-    handleRowHovered(api: GridApi, rowIndex: number, row: RowNode) {
+    handleRowHovered(api: GridApi, visualRowIndex: number, row: RowNode) {
+        const rowIndex = parseInt(row.id);
         if (this.props.onDataChanged) {
             this.props.onDataChanged(
                 this.getDataWithRowsHoveredMarker((row, index, isHovered) => (index === rowIndex)),
@@ -133,6 +137,10 @@ class DataGrid extends React.Component<DataGridProps, undefined> {
         };
     }
 
+    onGridReady(params) {
+        this.api = params.api;
+    }
+
     render() {
         const gridContext: DataGridContext = {
             theme: this.props.theme,
@@ -153,7 +161,9 @@ class DataGrid extends React.Component<DataGridProps, undefined> {
                     columnDefs={columnDefs}
                     rowData={rowData}
                     enableFilter
+                    enableSorting
                     context={gridContext}
+                    onGridReady={this.onGridReady}
                 />
             </Wrapper>
         );

--- a/frontend/src/components/universal/DataGrid/index.tsx
+++ b/frontend/src/components/universal/DataGrid/index.tsx
@@ -74,8 +74,6 @@ export interface AgGridDataFormat {
 
 class DataGrid extends React.Component<DataGridProps, undefined> {
 
-    api: any;
-
     constructor(props) {
         super(props);
 
@@ -137,10 +135,6 @@ class DataGrid extends React.Component<DataGridProps, undefined> {
         };
     }
 
-    onGridReady(params) {
-        this.api = params.api;
-    }
-
     render() {
         const gridContext: DataGridContext = {
             theme: this.props.theme,
@@ -163,7 +157,6 @@ class DataGrid extends React.Component<DataGridProps, undefined> {
                     enableFilter
                     enableSorting
                     context={gridContext}
-                    onGridReady={this.onGridReady}
                 />
             </Wrapper>
         );


### PR DESCRIPTION
This PR adds rows sorting functionality to the existing data grid.
It also fixes issue with hovering rows (indexes mismatch) - on filtering or sorting wrong row was hovered.

![image](https://user-images.githubusercontent.com/7319352/53686777-e0728380-3d2b-11e9-901e-2429b7e43093.png)
