### PR TITLE
Fix frontend missing icons

### DIFF
--- a/frontend/src/components/App.tsx
+++ b/frontend/src/components/App.tsx
@@ -11,13 +11,15 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
     faUserCircle, faTachometerAlt, faSearchDollar,
     faTools, faChartBar, faDownload, faUpload, faShieldAlt,
-    faCommentAlt, faFlag, faPlus
+    faCommentAlt, faFlag, faPlus, faDollarSign,
+    faRulerHorizontal, faRulerVertical, faChartArea, faClock, faChartLine
 } from '@fortawesome/free-solid-svg-icons';
 
 library.add(
      faUserCircle, faTachometerAlt, faSearchDollar,
      faTools, faChartBar, faDownload, faUpload, faShieldAlt,
-     faCommentAlt, faFlag, faPlus
+     faCommentAlt, faFlag, faPlus, faDollarSign,
+     faRulerHorizontal, faRulerVertical, faChartArea, faClock, faChartLine
 );
 
 const AppWrapper = styled.div`


### PR DESCRIPTION
**Merge #79 before that PR as conflicts may occur**
This PR is #77 ancestor.

This PR adds missing **FA** icons that weren't loaded, but are required by various UI components.