### PR TITLE
Extract theming from aggrid and plug into our theme

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -5,3 +5,4 @@ src/**/*.jsx
 tests/__coverage__/
 tests/**/*.jsx
 docs/
+tmp/

--- a/frontend/configs/webpack/common.js
+++ b/frontend/configs/webpack/common.js
@@ -68,12 +68,12 @@ module.exports = {
                       "getTheme($keys)": (keys) => {
                           keys = keys.getValue().split(".");
                           let result = sassVars;
-                          let i;
-                          for (i = 0; i < keys.length; i++) {
-                            result = result[keys[i]];
-                          }
-                          result = sassUtils.castToSass(result);
-                          return result;
+
+                          keys.forEach(key => {
+                              result = result[key];
+                          });
+
+                          return sassUtils.castToSass(result);
                       },
                   },
               },

--- a/frontend/configs/webpack/common.js
+++ b/frontend/configs/webpack/common.js
@@ -1,7 +1,13 @@
+require('typescript-require');
+
 // shared config (dev and prod)
 const path = require('path');
-const {CheckerPlugin} = require('awesome-typescript-loader');
+const { CheckerPlugin } = require('awesome-typescript-loader');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
+const sass = require("node-sass");
+const sassUtils = require("node-sass-utils")(sass);
+
+const sassVars = require(path.join(__dirname, "../../src/themes/default.ts"));
 
 module.exports = {
   resolve: {
@@ -55,7 +61,23 @@ module.exports = {
         loaders: [
           'style-loader',
           { loader: 'css-loader', options: { importLoaders: 1 } },
-          'sass-loader',
+          {
+              loader: 'sass-loader',
+              options: {
+                  functions: {
+                      "getTheme($keys)": (keys) => {
+                          keys = keys.getValue().split(".");
+                          let result = sassVars;
+                          let i;
+                          for (i = 0; i < keys.length; i++) {
+                            result = result[keys[i]];
+                          }
+                          result = sassUtils.castToSass(result);
+                          return result;
+                      },
+                  },
+              },
+          },
         ],
       },
       {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -81,9 +81,11 @@
     "@types/styled-components": "^4.1.4",
     "ag-grid-community": "^19.1.4",
     "ag-grid-react": "^19.1.2",
+    "ajv": "6.8.1",
     "axios": "^0.18.0",
     "moment": "^2.23.0",
     "node-polyglot": "^2.3.0",
+    "node-sass-utils": "^1.1.2",
     "rc-tooltip": "^3.7.3",
     "react-absolute-grid": "^3.0.1",
     "react-flip-move": "^3.0.3",
@@ -92,10 +94,10 @@
     "react-polyglot": "^0.2.6",
     "react-router-dom": "^4.3.1",
     "react-search-input": "^0.11.3",
-    "recharts": "^1.4.2",
     "react-svg-gauge": "^1.0.10",
+    "recharts": "^1.4.2",
     "styled-components": "^4.1.3",
-    "ajv": "6.8.1"
+    "typescript-require": "^0.2.10"
   },
   "jest": {
     "verbose": true,

--- a/frontend/src/components/universal/DataGrid/CellRenderer.tsx
+++ b/frontend/src/components/universal/DataGrid/CellRenderer.tsx
@@ -13,7 +13,7 @@ interface CellWrapperProps {
 }
 
 const CellWrapper = styled.div<CellWrapperProps>`
-  background: ${(props: CellWrapperProps) => props.theme.colors.background};
+  background: transparent;
   width: 100%;
   height: 100%;
   padding-left: 1vw;

--- a/frontend/src/components/universal/DataGrid/index.tsx
+++ b/frontend/src/components/universal/DataGrid/index.tsx
@@ -7,8 +7,7 @@ import { AgGridReact } from "ag-grid-react";
 import { resolveData, withData, DataFormat, FormatedDataPoint, RowSpecs } from "components/DataProvider";
 
 import "ag-grid-community/dist/styles/ag-grid.css";
-import "ag-grid-community/dist/styles/ag-theme-balham.css";
-import "./index.scss";
+import "./theme/index.scss";
 
 import CellRenderer from "./CellRenderer";
 import FilterRenderer from "./FilterRenderer";

--- a/frontend/src/components/universal/DataGrid/theme/ag-theme-common.scss
+++ b/frontend/src/components/universal/DataGrid/theme/ag-theme-common.scss
@@ -1,0 +1,319 @@
+@import "~ag-grid-community/src/styles/ag-theme-common";
+
+$foreground-opacity: 0.87 !default;
+$secondary-foreground-color-opacity: 0.54 !default;
+$disabled-foreground-color-opacity: 0.38 !default;
+
+@mixin ag-theme-balham($params) {
+    $border-color: map-get($params, "border-color");
+    $default-background: map-get($params, "default-background");
+    $foreground-color: map-get($params, "foreground-color");
+    $grid-size: map-get($params, "grid-size");
+    $header-background-color: map-get($params, "header-background-color");
+    $header-height: map-get($params, "header-height");
+    $icon-size: map-get($params, "icon-size");
+    $panel-background-color: map-get($params, "panel-background-color");
+    $primary-color: map-get($params, "primary-color");
+    $range-selection-highlight-color: map-get($params, "range-selection-highlight-color");
+    $row-height: map-get($params, "row-height");
+    $row-border-width: map-get($params, "row-border-width");
+    $selected-color: map-get($params, "selected-color");
+
+    .ag-header,
+    .ag-row,
+    .ag-header-cell,
+    .ag-header-group-cell,
+    .ag-rich-select-value,
+    .ag-root {
+        box-sizing: border-box;
+    }
+
+    %card {
+        border: 1px solid $border-color;
+    }
+
+    %tab {
+        border: 1px solid transparent;
+        border-bottom-width: 0;
+        display: inline-block;
+        margin: $grid-size;
+        margin-bottom: 0;
+        padding: $grid-size $grid-size * 2;
+    }
+
+    %selected-tab {
+        background-color: $default-background;
+        border-bottom: 2px solid $primary-color;
+        border-bottom: 2px solid $default-background;
+        border-color: $border-color;
+    }
+
+    @include ag-grid-theme($params);
+
+    .ag-header {
+        background-color: $header-background-color;
+        border-bottom: 1px solid $border-color;
+    }
+
+    .ag-pinned-right-header {
+        border-left: 1px solid $border-color;
+    }
+
+    .ag-pinned-left-header {
+        border-right: 1px solid $border-color;
+    }
+
+    .ag-cell-highlight {
+        background-color: $range-selection-highlight-color !important;
+    }
+
+    .ag-header-cell-resize::after {
+        height: 80%;
+        margin-top: $grid-size * 2;
+    }
+
+    .ag-header-cell::after,
+    .ag-header-group-cell::after {
+        border-right: 1px solid transparentize($border-color, 0.5);
+        content: " ";
+        height: $header-height - $grid-size * 4;
+        margin-top: $grid-size * 2;
+        position: absolute;
+        right: 0;
+        text-indent: -2000px;
+        top: 0;
+    }
+
+    .ag-column-drop-horizontal.ag-column-drop {
+        border: 1px solid $border-color;
+        border-bottom: 0;
+    }
+
+    .ag-column-drop-horizontal.ag-column-drop.ag-width-half:first-child {
+        border-right: 0;
+    }
+
+    .ag-row {
+        border-color: lighten($border-color, 10);
+    }
+
+    .ag-row-selected {
+        border-color: $selected-color;
+    }
+
+    .ag-row-drag {
+        background-position-y: center;
+    }
+
+    .ag-column-drag {
+        background-position-y: center;
+    }
+
+    .ag-column-drop-cell {
+        height: $grid-size * 6 !important;
+
+        .ag-column-drop-cell-button {
+            box-sizing: border-box;
+            height: calc(100% - #{$grid-size});
+            margin-bottom: $grid-size / 2;
+            margin-top: $grid-size / 2;
+        }
+
+        .ag-column-drop-cell-button:hover {
+            opacity: 1;
+            // border: 1px solid $border-color;
+        }
+    }
+
+    .ag-column-drop-vertical .ag-column-drop-cell {
+        margin-left: $grid-size * 2;
+        margin-right: $grid-size * 2;
+
+        .ag-column-drop-cell-text {
+            line-height: $grid-size * 6;
+            margin-left: $grid-size * 2;
+        }
+    }
+
+    .ag-column-drop-horizontal {
+        background-color: $panel-background-color;
+        height: $header-height;
+
+        .ag-column-drop-empty-message {
+            line-height: $header-height;
+        }
+
+        .ag-column-drop-cell-text {
+            line-height: $grid-size * 6;
+            margin-left: $grid-size * 2;
+        }
+    }
+
+    .ag-filter .ag-filter-header-container {
+        height: $grid-size * 6;
+    }
+
+    .ag-root {
+        border: 1px solid $border-color;
+    }
+
+    // bootstrap overrides
+    .ag-tab {
+        box-sizing: initial;
+    }
+
+    .ag-filter .ag-filter-value {
+        line-height: $icon-size + $grid-size;
+    }
+
+    // tool panel
+    .ag-tool-panel-wrapper {
+        border-right: 1px solid $border-color;
+        border-bottom: 1px solid $border-color;
+
+        .ag-column-select-panel {
+            padding-bottom: $grid-size * 2;
+
+            .ag-column-tool-panel-column-group,
+            .ag-column-tool-panel-column {
+                height: $grid-size * 5;
+                line-height: $grid-size * 5;
+            }
+        }
+
+        .ag-column-drop {
+            padding-bottom: $grid-size * 2;
+            padding-top: $grid-size * 2;
+
+            .ag-icon {
+                margin-bottom: $grid-size;
+            }
+
+            .ag-column-drop-title {
+                display: inline-block;
+                float: none;
+                margin-bottom: $grid-size;
+            }
+
+            .ag-column-drop-empty-message {
+                height: $grid-size * 4;
+                line-height: $grid-size * 4;
+                padding-left: $icon-size + $grid-size * 2;
+            }
+        }
+    }
+
+    .ag-rtl .ag-side-bar,
+    .ag-rtl .ag-tool-panel-wrapper {
+        border-left: 1px solid $border-color;
+        border-right: 0;
+    }
+
+    // real crude adjustments, due to line of elements with display: inline-block in the group cell
+    .ag-icon-expanded,
+    .ag-icon-contracted {
+        transform: translateY(2px);
+    }
+
+    .ag-rtl .ag-icon-expanded {
+        transform: translateY(2px) rotate(180deg);
+    }
+
+    // context menu spacing
+    .ag-menu-option {
+        height: $grid-size * 7;
+        line-height: $grid-size * 7;
+    }
+
+    .ag-column-select-panel {
+        .ag-column-tool-panel-column-group,
+        .ag-column-tool-panel-column {
+            height: $grid-size * 5;
+            line-height: $grid-size * 5;
+        }
+    }
+
+    .ag-filter-filter {
+        margin-left: $grid-size;
+        margin-right: $grid-size;
+        width: calc(100% - #{$grid-size * 2});
+    }
+
+    .ag-tab-header {
+        border-bottom: 1px solid $border-color;
+
+        .ag-tab {
+            margin-bottom: -2px;
+        }
+
+        .ag-tab.ag-tab-selected {
+            background-color: $default-background;
+            border-bottom-color: transparent;
+        }
+    }
+
+    .ag-tab-body,
+    .ag-popup-editor,
+    .ag-menu {
+        background-color: $default-background;
+        color: $foreground-color;
+    }
+
+    .ag-cell-inline-editing {
+        height: $row-height;
+        padding: 0;
+
+        input {
+            box-sizing: border-box;
+        }
+    }
+
+    .ag-details-row {
+        background-color: $default-background;
+    }
+
+    .ag-overlay-loading-wrapper {
+        background-color: rgba(255, 255, 255, 0.5);
+    }
+
+    .ag-overlay-loading-center {
+        background-color: $default-background;
+        border: 1px solid $border-color;
+        color: $foreground-color;
+        padding: $grid-size * 4;
+    }
+
+    $ag-range-selected-color-1: map-get($params, "ag-range-selected-color-1");
+    $ag-range-selected-color-2: map-get($params, "ag-range-selected-color-2");
+    $ag-range-selected-color-3: map-get($params, "ag-range-selected-color-3");
+    $ag-range-selected-color-4: map-get($params, "ag-range-selected-color-4");
+
+    // we do not want to color the range color when the cell is also focused
+    .ag-cell-range-selected-1:not(.ag-cell-focus) {
+        background-color: $ag-range-selected-color-1;
+    }
+
+    .ag-cell-range-selected-2:not(.ag-cell-focus) {
+        background-color: $ag-range-selected-color-2;
+    }
+
+    .ag-cell-range-selected-3:not(.ag-cell-focus) {
+        background-color: $ag-range-selected-color-3;
+    }
+
+    .ag-cell-range-selected-4:not(.ag-cell-focus) {
+        background-color: $ag-range-selected-color-4;
+    }
+
+    .ag-rich-select-value {
+        border-bottom: 1px solid $border-color;
+    }
+
+    .ag-filter-apply-panel {
+        border-top: 1px solid $border-color;
+    }
+
+    .ag-header-cell-moving {
+        background-color: $default-background;
+    }
+}

--- a/frontend/src/components/universal/DataGrid/theme/ag-theme-vars.scss
+++ b/frontend/src/components/universal/DataGrid/theme/ag-theme-vars.scss
@@ -1,0 +1,91 @@
+// Sizing
+$grid-size: 4px !default;
+$icon-size: 16px !default;
+
+// these three should be changed in envronment.ts, too
+$row-height: $grid-size * 7 !default;
+$header-height: $grid-size * 8 !default;
+$virtual-item-height: $grid-size * 7;
+$row-border-width: 1px !default;
+
+$toolpanel-indent-size: $grid-size + $icon-size !default;
+$row-group-indent-size: $grid-size * 3 + $icon-size !default;
+$cell-horizontal-padding: $grid-size * 3 !default;
+
+$header-icon-size: 14px !default;
+$border-radius: 2px;
+
+// Icons
+$icons-path: "~ag-grid-community/src/styles/balham-icons/" !default;
+
+// Fonts
+$font-family: getTheme('primaryFont') !default;
+
+$font-size: 12px !default;
+$font-weight: 400 !default;
+
+$secondary-font-family: $font-family !default; //font-secondary
+$secondary-font-size: 12px !default; // font-secondary-size
+$secondary-font-weight: 600 !default; // font-secondary-weight
+
+$transition-speed: 120ms !default;
+
+$params: (
+    default-background: $default-background,
+    grid-size: $grid-size,
+    icon-size: $icon-size,
+    header-background-color: $header-background-color,
+    header-icon-size: $header-icon-size,
+    row-height: $row-height,
+    row-border-width: $row-border-width,
+    header-height: $header-height,
+    virtual-item-height: $virtual-item-height,
+    rich-select-item-height: $row-height,
+    cell-horizontal-padding: $cell-horizontal-padding,
+    toolpanel-indent-size: $toolpanel-indent-size,
+    row-group-indent-size: $row-group-indent-size,
+    icons-path: $icons-path,
+    font-family: $font-family,
+    font-size: $font-size,
+    font-weight: $font-weight,
+    secondary-font-family: $secondary-font-family,
+    secondary-font-size: $secondary-font-size,
+    secondary-font-weight: $secondary-font-weight,
+    foreground-color: $foreground-color,
+    foreground-opacity: $foreground-opacity,
+    secondary-foreground-color-opacity: $secondary-foreground-color-opacity,
+    secondary-foreground-color: $secondary-foreground-color,
+    disabled-foreground-color-opacity: $disabled-foreground-color-opacity,
+    disabled-foreground-color: $disabled-foreground-color,
+    background-color: $background-color,
+    border-color: $border-color,
+    icon-color: $icon-color,
+    alt-icon-color: $alt-icon-color,
+    cell-data-changed-color: $cell-data-changed-color,
+    chip-background-color: $chip-background-color,
+    card-background-color: $background-color,
+    editor-background-color-color: $editor-background-color,
+    range-selection-background-color: $range-selection-background-color,
+    range-selection-highlight-color: $range-selection-highlight-color,
+    panel-background-color: $panel-background-color,
+    tool-panel-background-color: $tool-panel-background-color,
+    accent-color: $accent-color,
+    primary-color: $primary-color,
+    hover-color: $hover-color,
+    selected-color: $selected-color,
+    icon-opacity: $foreground-opacity,
+    button-text-transform: uppercase,
+    card-radius: 0,
+    card-shadow: none,
+    input-height: $grid-size * 4,
+    use-icons-for-pager-buttons: true,
+    value-change-delta-up-color: $value-change-delta-up-color,
+    value-change-delta-down-color: $value-change-delta-down-color,
+    value-change-value-highlight-background-color: $value-change-value-highlight-background-color,
+    odd-row-background-color: $odd-row-background-color,
+
+    ag-range-selected-color-1: opacify($range-selection-background-color, 0.1),
+    ag-range-selected-color-2: opacify($range-selection-background-color, 0.2),
+    ag-range-selected-color-3: opacify($range-selection-background-color, 0.3),
+    ag-range-selected-color-4: opacify($range-selection-background-color, 0.4)
+);

--- a/frontend/src/components/universal/DataGrid/theme/ag-theme.scss
+++ b/frontend/src/components/universal/DataGrid/theme/ag-theme.scss
@@ -1,0 +1,56 @@
+@import "./ag-theme-common";
+@import "~ag-grid-community/src/styles/flat-colors";
+
+// theme shortcuts
+$default-background: white !default;
+$chrome-background: $default-background !default;
+$active: #0091EA !default;
+$foreground-color: #000 !default;
+$border-color: $flat-silver !default;
+$icon-color: $flat-gray-4 !default;
+$alt-background: $default-background !default;
+$odd-row-background-color: $default-background !default;
+
+// Derived from above
+$foreground-color: rgba($foreground-color, $foreground-opacity) !default; // foreground
+$secondary-foreground-color: rgba($foreground-color, $secondary-foreground-color-opacity) !default; // foreground-secondary
+$disabled-foreground-color: rgba($foreground-color, $disabled-foreground-color-opacity) !default; // foreground-disabled
+
+$primary-color: $active !default;
+$accent-color: $active !default;
+$range-selection-background-color: transparentize($active, 0.8) !default;
+$range-selection-highlight-color: $active !default;
+$selected-color: lighten($active, 40) !default;
+
+$alt-icon-color: $default-background !default;
+$background-color: $default-background !default;
+
+$editor-background-color: $chrome-background !default;
+$panel-background-color: $chrome-background !default;
+$tool-panel-background-color: $chrome-background !default;
+$header-background-color: $chrome-background !default;
+
+$hover-color: $alt-background !default;
+$chip-background-color: darken($alt-background, 5) !default;
+
+// delta changes
+$cell-data-changed-color: #fce4ec !default;
+$value-change-delta-up-color: #43a047 !default;
+$value-change-delta-down-color: #e53935 !default;
+$value-change-value-highlight-background-color: transparentize(#16A085, 0.5) !default;
+
+@import './ag-theme-vars';
+
+.ag-theme-balham {
+    @include ag-theme-balham($params);
+
+    .ag-filter-toolpanel-body{
+        background-color: $background-color;
+    }
+    
+    .ag-root {
+        border: none;
+    }
+}
+
+

--- a/frontend/src/components/universal/DataGrid/theme/index.scss
+++ b/frontend/src/components/universal/DataGrid/theme/index.scss
@@ -1,3 +1,5 @@
+@import "./ag-theme.scss";
+
 .ag-cell.ag-cell-with-height.ag-cell-value {
     height: 100%;
 }


### PR DESCRIPTION
This PR extracts styling from agGrid theme `ag-theme-balham` and plugs into it our own theming system.
The entire mechanism is not perfect, but is quite fine for now.

* `theme/*` files were extracted from `balham` theme sources and changed to meet our visual standards
* `typescript-require` is used to load typescript file inside webpack config (theme `default.ts`)
* `sass-loader` was configured to provide `getTheme(property)` function that returns SASS variable extracted from `themes/default.ts` file
* Visually outer border round the grid was removed
* Visually background color was changed to match the colors of the rest of the layout

![image](https://user-images.githubusercontent.com/7319352/54088864-d15e8780-4362-11e9-8159-7a4f5901a60d.png)
