### PR TITLE
Add popover prop to TinyButtons

### DIFF
--- a/frontend/src/components/universal/TinyButtons/index.tsx
+++ b/frontend/src/components/universal/TinyButtons/index.tsx
@@ -4,6 +4,7 @@ import styled  from "styled-components";
 import { IconName } from "@fortawesome/fontawesome-svg-core";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
+import Popover from "components/Popover";
 import Tooltip from "components/Tooltip";
 
 const Wrapper = styled.div`
@@ -41,6 +42,7 @@ export interface ButtonSpecs {
     onClick?: () => void;
     text?: string;
     tooltip?: React.ReactElement<any>;
+    popover?: React.ReactElement<any>;
 }
 
 export interface TinyButtonsProps {
@@ -81,6 +83,16 @@ class TinyButtons extends React.Component<TinyButtonsProps, any> {
                             </span>
                         );
 
+                        if(button.popover) {
+                            contentNode = (
+                                <Popover
+                                    content={button.popover}
+                                >
+                                    {contentNode}
+                                </Popover>
+                            );
+                        }
+                        
                         if (button.tooltip) {
                             contentNode = (
                                 <Tooltip


### PR DESCRIPTION
This PR is a successor of #104.
It adds popover component support to `TinyButtons` so that you can render popover using provided prop option:

```
<TinyButtons>
    {
        [
            {
                icon: faDownload.iconName,
                popover: (
                    <div style={{color: 'black'}}>
                        ELO!
                    </div>
                ),
            },
        ]
    }
</TinyButtons>
```

![image](https://user-images.githubusercontent.com/7319352/54156564-cda43100-4446-11e9-8e25-e3c4978948ed.png)
