### PR TITLE
Implement abstract tree for forms

### DIFF
--- a/frontend/src/components/universal/Form/compositeNodes.tsx
+++ b/frontend/src/components/universal/Form/compositeNodes.tsx
@@ -1,0 +1,80 @@
+import * as React from "react";
+
+import {
+    Node,
+    NodeAny,
+    NodeHandler,
+    NodeOutputValue,
+    NodeSchema,
+    NodeState,
+    SchemaParserConfig,
+    SchemaTreeResolver,
+} from "./schemaTypes";
+
+export type NodeS = {
+    [key: string]: NodeState<any>;
+};
+
+export type NodeO = {
+    [key: string]: NodeOutputValue<any>;
+};
+
+export type ChildrenMap<T> = {
+    [key: string]: T;
+};
+
+export abstract class CompositeNodeHandler<O, M extends NodeSchema> extends NodeHandler<NodeS, O, M> {
+
+    abstract getChildrenMapFromSchema(schemaNode: M): ChildrenMap<NodeSchema>;
+
+    abstract getCompositeOutput(output: NodeO, schemaNode: M, node: Node<NodeS, O, M>): NodeOutputValue<O>;
+
+    renderComposite(children: ChildrenMap<React.ReactNode>, schemaNode: M, node: Node<NodeS, O, M>, parentNode: NodeAny, config: SchemaParserConfig) {
+        return Object.values(children);
+    }
+
+    resolveInitialState(schemaNode: M) {
+        const initialState = {};
+        Object.keys(this.getChildrenMapFromSchema(schemaNode)).forEach(key => {
+            initialState[key] = null;
+        });
+        return initialState;
+    }
+
+    getOutput(schemaNode: M, node: Node<NodeS, O, M>) {
+        const output = {};
+        Object.keys(this.getChildrenMapFromSchema(schemaNode)).forEach(key => {
+            output[key] = node.findChild(key).getOutput();
+        });
+        return this.getCompositeOutput(output, schemaNode, node);
+    }
+
+    resolveChildren(schemaNode: M, node: Node<NodeS, O, M>, parentNode: NodeAny, config: SchemaParserConfig, resolve: SchemaTreeResolver) {
+        const childrenMap: ChildrenMap<NodeSchema> = this.getChildrenMapFromSchema(schemaNode);
+
+        return Object.keys(childrenMap).map(key => {
+            return {
+                ...resolve(childrenMap[key], {
+                    ...node,
+                    setState: (state: NodeState<any>) => {
+                        node.setState({
+                            ...node.state,
+                            [key]: state,
+                        });
+                    },
+                }, config),
+                tag: key,
+            };
+        });
+    }
+
+    render(schemaNode: M, node: Node<NodeS, O, M>, parentNode: NodeAny, config: SchemaParserConfig) {
+        const childrenMap: ChildrenMap<React.ReactNode> = {};
+
+        Object.keys(this.getChildrenMapFromSchema(schemaNode)).forEach((key: string, index: number) => {
+            childrenMap[key] = node.findChild(key).render();
+        });
+
+        return this.renderComposite(childrenMap, schemaNode, node, parentNode, config);
+    }
+}

--- a/frontend/src/components/universal/Form/defaultParserConfig.tsx
+++ b/frontend/src/components/universal/Form/defaultParserConfig.tsx
@@ -1,4 +1,4 @@
-import { SchemaParserConfig, NodeState, NodeAny } from "./schemaTypes";
+import { NodeAny, NodeState, SchemaParserConfig } from "./schemaTypes";
 
 import ObjectDefault from "./renderers/ObjectDefault";
 import StringDefault from "./renderers/StringDefault";
@@ -9,10 +9,10 @@ export const defaultParserConfig: SchemaParserConfig = {
             default: null,
         },
         STRING: {
-            default: StringDefault,
+            default: new StringDefault(),
         },
         OBJECT: {
-            default: ObjectDefault,
+            default: new ObjectDefault(),
         },
     },
     rootState: null,

--- a/frontend/src/components/universal/Form/defaultParserConfig.tsx
+++ b/frontend/src/components/universal/Form/defaultParserConfig.tsx
@@ -1,4 +1,4 @@
-import { SchemaParserConfig, NodeState, Node } from "./schemaTypes";
+import { SchemaParserConfig, NodeState, NodeAny } from "./schemaTypes";
 
 import ObjectDefault from "./renderers/ObjectDefault";
 import StringDefault from "./renderers/StringDefault";
@@ -16,5 +16,5 @@ export const defaultParserConfig: SchemaParserConfig = {
         },
     },
     rootState: null,
-    rootSetState: (state: NodeState, root: Node) => {},
+    rootSetState: (state: NodeState<any>, root: NodeAny) => {},
 };

--- a/frontend/src/components/universal/Form/defaultParserConfig.tsx
+++ b/frontend/src/components/universal/Form/defaultParserConfig.tsx
@@ -1,10 +1,13 @@
-import { SchemaParserConfig } from "./schemaTypes";
+import { SchemaParserConfig, NodeState, Node } from "./schemaTypes";
 
 import ObjectDefault from "./renderers/ObjectDefault";
 import StringDefault from "./renderers/StringDefault";
 
 export const defaultParserConfig: SchemaParserConfig = {
-    renderers: {
+    handlers: {
+        ROOT: {
+            default: null,
+        },
         STRING: {
             default: StringDefault,
         },
@@ -12,4 +15,6 @@ export const defaultParserConfig: SchemaParserConfig = {
             default: ObjectDefault,
         },
     },
+    rootState: null,
+    rootSetState: (state: NodeState, root: Node) => {},
 };

--- a/frontend/src/components/universal/Form/index.tsx
+++ b/frontend/src/components/universal/Form/index.tsx
@@ -62,7 +62,7 @@ export default class Form extends React.Component<FormProps, FormState> {
                 this.setState({
                     tree,
                 });
-            }, 0);
+            });
         }
     }
 
@@ -75,7 +75,7 @@ export default class Form extends React.Component<FormProps, FormState> {
 
         return (
             <Wrapper>
-                {(this.state.tree) ? (this.state.tree.render()) :(null)}
+                {(this.state.tree) ? (this.state.tree.render()) : (null)}
             </Wrapper>
         );
     }

--- a/frontend/src/components/universal/Form/index.tsx
+++ b/frontend/src/components/universal/Form/index.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import styled  from "styled-components";
 
 import { transformSchemaIntoTree } from "./schemaParser";
-import { NodeType, Schema, NodeState, Node } from "./schemaTypes";
+import { NodeType, Schema, NodeState, Node, NodeAny } from "./schemaTypes";
 
 const Wrapper = styled.div`
   width: 100%;
@@ -14,7 +14,7 @@ export interface FormProps {
 }
 
 interface FormState { 
-    tree: Node;
+    tree: NodeAny;
 }
 
 export default class Form extends React.Component<FormProps, FormState> {
@@ -29,7 +29,7 @@ export default class Form extends React.Component<FormProps, FormState> {
         };
     }
     
-    handleFormStateUpdate(state: NodeState, root: Node) {
+    handleFormStateUpdate(state: NodeState<any>, root: NodeAny) {
         console.error("SET FORM STATE!");
         console.log(root.getOutput());
         this.setState({
@@ -57,7 +57,7 @@ export default class Form extends React.Component<FormProps, FormState> {
         if (!this.state.tree) {
             setTimeout(() => {
                 const tree = transformSchemaIntoTree(schema, null, {
-                    rootSetState: (state: NodeState, root: Node) => this.handleFormStateUpdate(state, root),
+                    rootSetState: (state: NodeState<any>, root: NodeAny) => this.handleFormStateUpdate(state, root),
                     rootState: {},
                 });
                 

--- a/frontend/src/components/universal/Form/index.tsx
+++ b/frontend/src/components/universal/Form/index.tsx
@@ -1,20 +1,43 @@
 import * as React from "react";
 import styled  from "styled-components";
 
-import { transformTreeIntoUI } from "./schemaParser";
-import { NodeType, Schema } from "./schemaTypes";
+import { transformSchemaIntoTree } from "./schemaParser";
+import { NodeType, Schema, NodeState, Node } from "./schemaTypes";
 
 const Wrapper = styled.div`
   width: 100%;
 `;
 
-interface FormProps {
-  fontSize?: string;
-  theme?: any;
+export interface FormProps {
+    fontSize?: string;
+    theme?: any;
 }
 
-export default class Form extends React.Component<FormProps, undefined> {
-    render() {
+interface FormState { 
+    tree: Node;
+}
+
+export default class Form extends React.Component<FormProps, FormState> {
+    
+    state: FormState;
+    
+    constructor(props) {
+        super(props);
+        
+        this.state = {
+            tree: null,
+        };
+    }
+    
+    handleFormStateUpdate(state: NodeState, root: Node) {
+        console.error("SET FORM STATE!");
+        console.log(root.getOutput());
+        this.setState({
+            tree: root,
+        });
+    }
+    
+    createTree() {
         const schema: Schema = {
             title: "A registration form",
             description: "The description",
@@ -24,12 +47,40 @@ export default class Form extends React.Component<FormProps, undefined> {
                     type: NodeType.STRING,
                     title: "Your first name",
                 },
+                "lastName": {
+                    type: NodeType.STRING,
+                    title: "Your last name",
+                },
             },
         };
-
+        
+        if (!this.state.tree) {
+            setTimeout(() => {
+                const tree = transformSchemaIntoTree(schema, null, {
+                    rootSetState: (state: NodeState, root: Node) => this.handleFormStateUpdate(state, root),
+                    rootState: {},
+                });
+                
+                console.error("SET FORM TREE!");
+                console.log(tree);
+                
+                this.setState({
+                    tree
+                });
+            }, 0);
+        }
+    }
+    
+    componentDidMount() {
+        this.createTree();
+    }
+    
+    render() {
+        this.createTree();
+        
         return (
             <Wrapper>
-                {transformTreeIntoUI(schema)}
+                {(this.state.tree)?(this.state.tree.render()):(null)}
             </Wrapper>
         );
     }

--- a/frontend/src/components/universal/Form/index.tsx
+++ b/frontend/src/components/universal/Form/index.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import styled  from "styled-components";
 
 import { transformSchemaIntoTree } from "./schemaParser";
-import { NodeType, Schema, NodeState, Node, NodeAny } from "./schemaTypes";
+import { NodeAny, NodeState, NodeType, Schema } from "./schemaTypes";
 
 const Wrapper = styled.div`
   width: 100%;
@@ -13,30 +13,28 @@ export interface FormProps {
     theme?: any;
 }
 
-interface FormState { 
+interface FormState {
     tree: NodeAny;
 }
 
 export default class Form extends React.Component<FormProps, FormState> {
-    
+
     state: FormState;
-    
+
     constructor(props) {
         super(props);
-        
+
         this.state = {
             tree: null,
         };
     }
-    
+
     handleFormStateUpdate(state: NodeState<any>, root: NodeAny) {
-        console.error("SET FORM STATE!");
-        console.log(root.getOutput());
         this.setState({
             tree: root,
         });
     }
-    
+
     createTree() {
         const schema: Schema = {
             title: "A registration form",
@@ -53,34 +51,31 @@ export default class Form extends React.Component<FormProps, FormState> {
                 },
             },
         };
-        
+
         if (!this.state.tree) {
             setTimeout(() => {
                 const tree = transformSchemaIntoTree(schema, null, {
                     rootSetState: (state: NodeState<any>, root: NodeAny) => this.handleFormStateUpdate(state, root),
                     rootState: {},
                 });
-                
-                console.error("SET FORM TREE!");
-                console.log(tree);
-                
+
                 this.setState({
-                    tree
+                    tree,
                 });
             }, 0);
         }
     }
-    
+
     componentDidMount() {
         this.createTree();
     }
-    
+
     render() {
         this.createTree();
-        
+
         return (
             <Wrapper>
-                {(this.state.tree)?(this.state.tree.render()):(null)}
+                {(this.state.tree) ? (this.state.tree.render()) :(null)}
             </Wrapper>
         );
     }

--- a/frontend/src/components/universal/Form/renderers/ObjectDefault.tsx
+++ b/frontend/src/components/universal/Form/renderers/ObjectDefault.tsx
@@ -1,76 +1,17 @@
-import * as React from "react";
+import { CompositeNodeHandler, NodeO } from "../compositeNodes";
 
 import {
     NodeObjectSchema,
-    SchemaParserConfig,
-    SchemaTreeResolver,
-    NodeState,
-    NodeOutputValue,
-    NodeSchema,
-    NodeHandler,
-    Node,
-    NodeAny,
 } from "../schemaTypes";
 
-type NodeS = {
-    [key: string]: NodeState<any>;
-};
+export default class ObjectDefault extends CompositeNodeHandler<NodeO, NodeObjectSchema> {
 
-type NodeO = {
-    [key: string]: NodeOutputValue<any>;
-};
+    getChildrenMapFromSchema(schemaNode: NodeObjectSchema) {
+        return schemaNode.properties;
+    }
 
-type NodeSelf = Node<NodeS, NodeO, NodeObjectSchema>;
-
-const handler: NodeHandler<NodeS, NodeO, NodeObjectSchema> = {
-    
-    resolveInitialState: (schemaNode: NodeObjectSchema) => {
-        const initialState = {};
-        Object.keys(schemaNode.properties).forEach(key => {
-            initialState[key] = null;
-        });
-        return initialState;
-    },
-    getOutput: (schemaNode: NodeObjectSchema, node: NodeSelf) => {
-        const output = {};
-        Object.keys(schemaNode.properties).forEach(key => {
-            output[key] = node.findChild(key).getOutput();
-        });
+    getCompositeOutput(output: NodeO) {
         return output;
-    },
-    resolveChildren: (schemaNode: NodeObjectSchema, node: NodeSelf, parentNode: NodeAny, config: SchemaParserConfig, resolve: SchemaTreeResolver) => {
-        return Object.keys(schemaNode.properties).map(key => {
-            return {
-                ...resolve(schemaNode.properties[key], {
-                    ...node,
-                    setState: (state: NodeState<any>) => {
-                        node.setState({
-                            ...node.state,
-                            [key]: state,
-                        })
-                    },
-                }, config),
-                tag: key,
-            };
-        });
-    },
-    render: (schemaNode: NodeObjectSchema, node: NodeSelf, parentNode: NodeAny, config: SchemaParserConfig) => {
-        return (
-            <div>
-                {
-                    Object.keys(schemaNode.properties).map((key: string, index: number) => {
-                        return (
-                            <div key={`form-ui-${index}`} >
-                                {
-                                    node.findChild(key).render()
-                                }
-                            </div>
-                        );
-                    })
-                }
-            </div>
-        );
-    },
-};
+    }
 
-export default handler;
+}

--- a/frontend/src/components/universal/Form/renderers/ObjectDefault.tsx
+++ b/frontend/src/components/universal/Form/renderers/ObjectDefault.tsx
@@ -3,21 +3,55 @@ import * as React from "react";
 import {
     NodeObjectSchema,
     SchemaParserConfig,
-    TreeUITransformer,
+    SchemaTreeResolver,
+    NodeState,
+    NodeSchema,
+    Node,
 } from "../schemaTypes";
 
 export default {
-    render: (node: NodeObjectSchema, transformer: TreeUITransformer, config: SchemaParserConfig) => {
-        const propertiesKeys: Array<string> = Object.keys(node.properties);
-
+    
+    resolveInitialState: (schemaNode: NodeObjectSchema) => {
+        const initialState = {};
+        Object.keys(schemaNode.properties).forEach(key => {
+            initialState[key] = null;
+        });
+        return initialState;
+    },
+    getOutput: (schemaNode: NodeObjectSchema, node: Node) => {
+        const output = {};
+        Object.keys(schemaNode.properties).forEach(key => {
+            output[key] = node.findChild(key).getOutput();
+        });
+        return output;
+    },
+    resolveChildren: (schemaNode: NodeObjectSchema, node: Node, parentNode: Node, config: SchemaParserConfig, resolve: SchemaTreeResolver) => {
+        return Object.keys(schemaNode.properties).map(key => {
+            return {
+                ...resolve(schemaNode.properties[key], {
+                    ...node,
+                    setState: (state: NodeState) => {
+                        node.setState({
+                            ...node.state,
+                            [key]: state,
+                        })
+                    },
+                }, config),
+                tag: key,
+            };
+        });
+    },
+    render: (schemaNode: NodeObjectSchema, node: Node, parentNode: Node, config: SchemaParserConfig) => {
         return (
             <div>
+                <b>Object keys</b>
                 {
-                    propertiesKeys.map((key: string, index: number) => {
+                    Object.keys(schemaNode.properties).map((key: string, index: number) => {
                         return (
                             <div key={`form-ui-${index}`} >
+                                <b>key = {key}</b>
                                 {
-                                    transformer(node.properties[key], config)
+                                    node.findChild(key).render()
                                 }
                             </div>
                         );

--- a/frontend/src/components/universal/Form/renderers/ObjectDefault.tsx
+++ b/frontend/src/components/universal/Form/renderers/ObjectDefault.tsx
@@ -5,11 +5,24 @@ import {
     SchemaParserConfig,
     SchemaTreeResolver,
     NodeState,
+    NodeOutputValue,
     NodeSchema,
+    NodeHandler,
     Node,
+    NodeAny,
 } from "../schemaTypes";
 
-export default {
+type NodeS = {
+    [key: string]: NodeState<any>;
+};
+
+type NodeO = {
+    [key: string]: NodeOutputValue<any>;
+};
+
+type NodeSelf = Node<NodeS, NodeO, NodeObjectSchema>;
+
+const handler: NodeHandler<NodeS, NodeO, NodeObjectSchema> = {
     
     resolveInitialState: (schemaNode: NodeObjectSchema) => {
         const initialState = {};
@@ -18,19 +31,19 @@ export default {
         });
         return initialState;
     },
-    getOutput: (schemaNode: NodeObjectSchema, node: Node) => {
+    getOutput: (schemaNode: NodeObjectSchema, node: NodeSelf) => {
         const output = {};
         Object.keys(schemaNode.properties).forEach(key => {
             output[key] = node.findChild(key).getOutput();
         });
         return output;
     },
-    resolveChildren: (schemaNode: NodeObjectSchema, node: Node, parentNode: Node, config: SchemaParserConfig, resolve: SchemaTreeResolver) => {
+    resolveChildren: (schemaNode: NodeObjectSchema, node: NodeSelf, parentNode: NodeAny, config: SchemaParserConfig, resolve: SchemaTreeResolver) => {
         return Object.keys(schemaNode.properties).map(key => {
             return {
                 ...resolve(schemaNode.properties[key], {
                     ...node,
-                    setState: (state: NodeState) => {
+                    setState: (state: NodeState<any>) => {
                         node.setState({
                             ...node.state,
                             [key]: state,
@@ -41,15 +54,13 @@ export default {
             };
         });
     },
-    render: (schemaNode: NodeObjectSchema, node: Node, parentNode: Node, config: SchemaParserConfig) => {
+    render: (schemaNode: NodeObjectSchema, node: NodeSelf, parentNode: NodeAny, config: SchemaParserConfig) => {
         return (
             <div>
-                <b>Object keys</b>
                 {
                     Object.keys(schemaNode.properties).map((key: string, index: number) => {
                         return (
                             <div key={`form-ui-${index}`} >
-                                <b>key = {key}</b>
                                 {
                                     node.findChild(key).render()
                                 }
@@ -61,3 +72,5 @@ export default {
         );
     },
 };
+
+export default handler;

--- a/frontend/src/components/universal/Form/renderers/StringDefault.tsx
+++ b/frontend/src/components/universal/Form/renderers/StringDefault.tsx
@@ -3,15 +3,34 @@ import * as React from "react";
 import {
     NodeStringSchema,
     SchemaParserConfig,
-    TreeUITransformer,
+    NodeSchema,
+    NodeState,
+    Node,
 } from "../schemaTypes";
 
 export default {
-    render: (node: NodeStringSchema, transformer: TreeUITransformer, config: SchemaParserConfig) => {
+    resolveInitialState: () => {
+        return {
+            value: '',
+        };
+    },
+    getOutput: (schemaNode: NodeSchema, node: Node) => {
+        return node.state.value;
+    },
+    render: (schemaNode: NodeSchema, node: Node) => {
         return (
             <div>
-                {node.title}
-                {node.description}
+                {schemaNode.title}
+                {schemaNode.description}
+                <input
+                    value={node.state.value}
+                    onChange={(event) => {
+                        node.setState({
+                            ...node.state,
+                            value: event.target.value || '',
+                        });
+                    }}
+                />
             </div>
         );
     },

--- a/frontend/src/components/universal/Form/renderers/StringDefault.tsx
+++ b/frontend/src/components/universal/Form/renderers/StringDefault.tsx
@@ -1,48 +1,32 @@
 import * as React from "react";
 
+import { SimpleNodeHandler } from "../simpleNodes";
+
 import {
-    NodeStringSchema,
-    SchemaParserConfig,
+    NodeAny,
     NodeSchema,
-    NodeHandler,
-    NodeState,
-    Node,
+    NodeStringSchema,
 } from "../schemaTypes";
 
-type NodeS = {
-    value: string;
-};
+export default class StringDefault extends SimpleNodeHandler<string, NodeStringSchema> {
+    getInitialValue() {
+        return "";
+    }
 
-type NodeO = string;
-
-type NodeSelf = Node<NodeS, NodeO, NodeStringSchema>;
-
-const handler: NodeHandler<NodeS, NodeO, NodeStringSchema> = {
-    resolveInitialState: () => {
-        return {
-            value: '',
-        };
-    },
-    getOutput: (schemaNode: NodeSchema, node: NodeSelf) => {
-        return node.state.value;
-    },
-    render: (schemaNode: NodeSchema, node: NodeSelf) => {
+    renderSimple(schemaNode: NodeSchema, value: string, node: NodeAny) {
         return (
             <div>
                 {schemaNode.title}
                 {schemaNode.description}
                 <input
-                    value={node.state.value}
+                    value={value}
                     onChange={(event) => {
                         node.setState({
-                            ...node.state,
-                            value: event.target.value || '',
+                            value: event.target.value || "",
                         });
                     }}
                 />
             </div>
         );
-    },
+    }
 }
-
-export default handler;

--- a/frontend/src/components/universal/Form/renderers/StringDefault.tsx
+++ b/frontend/src/components/universal/Form/renderers/StringDefault.tsx
@@ -4,20 +4,29 @@ import {
     NodeStringSchema,
     SchemaParserConfig,
     NodeSchema,
+    NodeHandler,
     NodeState,
     Node,
 } from "../schemaTypes";
 
-export default {
+type NodeS = {
+    value: string;
+};
+
+type NodeO = string;
+
+type NodeSelf = Node<NodeS, NodeO, NodeStringSchema>;
+
+const handler: NodeHandler<NodeS, NodeO, NodeStringSchema> = {
     resolveInitialState: () => {
         return {
             value: '',
         };
     },
-    getOutput: (schemaNode: NodeSchema, node: Node) => {
+    getOutput: (schemaNode: NodeSchema, node: NodeSelf) => {
         return node.state.value;
     },
-    render: (schemaNode: NodeSchema, node: Node) => {
+    render: (schemaNode: NodeSchema, node: NodeSelf) => {
         return (
             <div>
                 {schemaNode.title}
@@ -34,4 +43,6 @@ export default {
             </div>
         );
     },
-};
+}
+
+export default handler;

--- a/frontend/src/components/universal/Form/schemaParser.tsx
+++ b/frontend/src/components/universal/Form/schemaParser.tsx
@@ -15,10 +15,7 @@ import {
 import { defaultParserConfig } from "./defaultParserConfig";
 
 function getHandlerForUI<M extends NodeSchema>(node: M, handlers: SchemaNodeHandlersMappingForType<M>): NodeHandler<any, any, M> {
-    if (node.ui) {
-        return handlers[node.ui];
-    }
-    return handlers.default;
+    return node.ui ? handlers[node.ui] : handlers.default;
 }
 
 function getHandlerForType<M extends NodeSchema>(node: M, config: SchemaParserConfig): SchemaNodeHandlersMappingForType<NodeTypeSchemas[M["type"]]> {

--- a/frontend/src/components/universal/Form/schemaParser.tsx
+++ b/frontend/src/components/universal/Form/schemaParser.tsx
@@ -3,15 +3,120 @@ import * as React from "react";
 import {
     NodeSchema,
     NodeType,
+    NodeState,
+    Node,
     Schema,
     SchemaParserConfig,
-    SchemaRenderer,
-    SchemaRenderersMappingForType,
+    SchemaParserConfigOpt,
+    NodeHandler,
+    SchemaNodeHandlersMappingForType,
 } from "./schemaTypes";
 
 import { defaultParserConfig } from "./defaultParserConfig";
 
-export function recTransformTreeIntoUI(node: NodeSchema, config: SchemaParserConfig): React.ReactNode {
+export function recTransformSchemaIntoTree(node: NodeSchema, parentNode: Node, config: SchemaParserConfig): Node {
+    let handlersForType:  SchemaNodeHandlersMappingForType;
+
+    switch (node.type) {
+        case NodeType.OBJECT:
+            handlersForType = config.handlers.OBJECT;
+            break;
+        case NodeType.STRING:
+            handlersForType = config.handlers.STRING;
+            break;
+        default:
+            return null;
+    }
+
+    let handler: NodeHandler = handlersForType.default;
+    if (node.ui) {
+        handler = handlersForType[node.ui];
+    }
+    
+    const astNode: Node = {
+        state: null,
+        schemaNode: node,
+        type: node.type,
+        children: [],
+        tag: null,
+        findChild: (tag: string) => {
+            console.error('NODE FIND CHILD [NODE]! with tag = '+tag);
+            console.log(astNode.children);
+            return astNode.children.filter(child => child.tag === tag)[0]
+        },
+        getOutput: () => {
+            return astNode.state;
+        },
+        render: () => handler.render(node, astNode, parentNode, config),
+        setState: (state: NodeState) => {
+            if (state) {
+                Object.assign(astNode, { state });
+            }
+            parentNode.setState(astNode.state);
+        },
+        handler,
+    };
+    
+    if(handler.resolveInitialState) {
+        astNode.state = handler.resolveInitialState(node, astNode, parentNode, config, recTransformSchemaIntoTree);
+    }
+    
+    if(handler.resolveChildren) {
+        astNode.children = handler.resolveChildren(node, astNode, parentNode, config, recTransformSchemaIntoTree);
+    }
+    
+    if(handler.getOutput) {
+        astNode.getOutput = () => handler.getOutput(node, astNode, parentNode, config, recTransformSchemaIntoTree);
+    }
+    
+    parentNode.children.push(astNode);
+    
+    return astNode;
+}
+
+export function transformSchemaIntoTree(node: NodeSchema, rootNode: Node = null, config: SchemaParserConfigOpt = null): Node {
+    const conf = {...defaultParserConfig, ...config};
+    
+    if (!rootNode) {
+        rootNode = {
+            handler: null,
+            state: conf.rootState,
+            schemaNode: node,
+            type: NodeType.ROOT,
+            children: [],
+            getOutput: () => {
+                if (rootNode.children.length == 0) {
+                    return null;
+                } else if (rootNode.children.length == 1) {
+                    return rootNode.children[0].getOutput();
+                } else {
+                    return rootNode.children.map(child => child.getOutput());
+                }
+            },
+            render: () => {
+                console.log('ROOT RENDER!');
+                return rootNode.children.map(child => child.render());
+            },
+            setState: (state: NodeState) => {
+                if (state) {
+                    Object.assign(rootNode, { state });
+                }
+                conf.rootSetState(rootNode.state, rootNode);
+            },
+            tag: 'root',
+            findChild: (tag: string) => {
+                console.error('NODE FIND CHILD [ROOT]!');
+                console.log(rootNode.children);
+                return rootNode.children.filter(child => child.tag === tag)[0]
+            }
+        };
+    }
+    
+    recTransformSchemaIntoTree(node, rootNode, conf);
+    return rootNode;
+}
+
+/*export function recTransformTreeIntoUI(node: NodeSchema, config: SchemaParserConfig): React.ReactNode {
     let renderersForType: SchemaRenderersMappingForType;
 
     switch (node.type) {
@@ -33,6 +138,6 @@ export function recTransformTreeIntoUI(node: NodeSchema, config: SchemaParserCon
     return renderer.render(node, recTransformTreeIntoUI, config);
 }
 
-export function transformTreeIntoUI(schema: Schema, config: SchemaParserConfig = defaultParserConfig): React.ReactNode {
-    return recTransformTreeIntoUI(schema, config);
-}
+export function transformTreeIntoUI(schema: Schema, config: SchemaParserConfigOpt = null): React.ReactNode {
+    return recTransformTreeIntoUI(schema, {...defaultParserConfig, ...config});
+}*/

--- a/frontend/src/components/universal/Form/schemaTypes.tsx
+++ b/frontend/src/components/universal/Form/schemaTypes.tsx
@@ -1,9 +1,17 @@
 import * as React from "react";
 
+type ValueOf<T> = T[keyof T];
+
 export enum NodeType {
     STRING = "string",
     OBJECT = "object",
     ROOT = "root",
+}
+
+export interface NodeTypeSchemas {
+    STRING: NodeStringSchema;
+    OBJECT: NodeObjectSchema;
+    ROOT: any;
 }
 
 export interface NodeBaseSchema {
@@ -26,54 +34,67 @@ export interface NodeStringSchema extends NodeBaseSchema {
     type: NodeType.STRING;
 }
 
-export type NodeSchema = NodeObjectSchema | NodeStringSchema;
+export type NodeSchema = ValueOf<NodeTypeSchemas>;
 
 export type Schema = NodeObjectSchema;
 
-export interface NodeHandler {
-    render: (schemaNode: NodeSchema, node: Node, parentNode: Node, config: SchemaParserConfig) => React.ReactNode;
-    resolveInitialState?: (schemaNode: NodeSchema, node: Node, parentNode: Node, config: SchemaParserConfig, resolve: SchemaTreeResolver) => NodeState;
-    resolveChildren?: (schemaNode: NodeSchema, node: Node, parentNode: Node, config: SchemaParserConfig, resolve: SchemaTreeResolver) => Array<Node>;
-    getOutput?: (schemaNode: NodeSchema, node: Node, parentNode: Node, config: SchemaParserConfig, resolve: SchemaTreeResolver) => NodeOutputValue;
+export interface NodeHandler<
+  S, O, M extends NodeSchema,
+  CS = any, CO = any, CM extends NodeSchema = any,
+  PS = any, PO = any, PM extends NodeSchema = any
+> {
+    render: (schemaNode: M, node: Node<S, O, M>, parentNode: Node<PS, PO, PM>, config: SchemaParserConfig) => React.ReactNode;
+    resolveInitialState?: (schemaNode: M, node: Node<S, O, M>, parentNode: Node<PS, PO, PM>, config: SchemaParserConfig, resolve: SchemaTreeResolver) => NodeState<S>;
+    resolveChildren?: (schemaNode: M, node: Node<S, O, M>, parentNode: Node<PS, PO, PM>, config: SchemaParserConfig, resolve: SchemaTreeResolver) => Array<Node<CS, CO, CM>>;
+    getOutput?: (schemaNode: M, node: Node<S, O, M>, parentNode: Node<PS, PO, PM>, config: SchemaParserConfig, resolve: SchemaTreeResolver) => NodeOutputValue<O>;
 }
 
-export interface SchemaNodeHandlersMappingForType {
-    [key: string]: NodeHandler;
+export interface SchemaNodeHandlersMappingForType<M extends NodeSchema> {
+    [key: string]: NodeHandler<any, any, M>;
 }
 
-type NodeTypeNames = keyof typeof NodeType;
+export type NodeTypeNames = keyof typeof NodeType;
 
 export type SchemaNodeHandlersMapping = {
-    [key in NodeTypeNames]: SchemaNodeHandlersMappingForType;
+    [key in NodeTypeNames]: SchemaNodeHandlersMappingForType<NodeTypeSchemas[key]>;
 };
 
 export interface SchemaParserConfig {
     handlers: SchemaNodeHandlersMapping;
-    rootState: NodeState;
-    rootSetState?: (state: NodeState, root: Node) => void;
+    rootState: NodeState<any>;
+    rootSetState?: (state: NodeState<any>, root: NodeAny) => void;
 }
 
 export interface SchemaParserConfigOpt {
     handlers?: SchemaNodeHandlersMapping;
-    rootState?: NodeState;
-    rootSetState?: (state: NodeState, root: Node) => void;
+    rootState?: NodeState<any>;
+    rootSetState?: (state: NodeState<any>, root: NodeAny) => void;
 }
 
-export type NodeState = any;
+export type NodeState<S> = S;
 
-export type NodeOutputValue = any;
+export type NodeOutputValue<O> = O;
 
-export type SchemaTreeResolver = (node: NodeSchema, parentNode: Node, config: SchemaParserConfig) => Node;
+export type NodeAny = Node<any, any, any>;
 
-export interface Node {
-    state: NodeState;
+export type SchemaTreeResolver<
+  M extends NodeSchema = any,
+  PS = any, PO = any, PM extends NodeSchema = any
+> = (node: M, parentNode: Node<PS, PO, PM>, config: SchemaParserConfig) => Node<any, any, M>;
+
+export interface Node<
+ S, O, M extends NodeSchema,
+ CS = any, CO = any, CM extends NodeSchema = any,
+ PS = any, PO = any, PM extends NodeSchema = any
+> {
+    state: NodeState<S>;
     tag?: string;
     type: NodeType;
-    schemaNode: NodeSchema;
-    children: Array<Node>;
-    handler: NodeHandler;
+    schemaNode: M;
+    children: Array<Node<CS, CO, CM>>;
+    handler: NodeHandler<S, O, M, CS, CO, CM, PS, PO, PM>;
     render: () => React.ReactNode;
-    getOutput: () => NodeOutputValue;
-    setState: (state: NodeState) => void;
-    findChild: (tag: string) => Node;
+    getOutput: () => NodeOutputValue<O>;
+    setState: (state: NodeState<S>) => void;
+    findChild: (tag: string) => Node<CS, CO, CM>;
 }

--- a/frontend/src/components/universal/Form/schemaTypes.tsx
+++ b/frontend/src/components/universal/Form/schemaTypes.tsx
@@ -3,6 +3,7 @@ import * as React from "react";
 export enum NodeType {
     STRING = "string",
     OBJECT = "object",
+    ROOT = "root",
 }
 
 export interface NodeBaseSchema {
@@ -29,22 +30,50 @@ export type NodeSchema = NodeObjectSchema | NodeStringSchema;
 
 export type Schema = NodeObjectSchema;
 
-export interface SchemaRenderer {
-    render: (node: NodeSchema, transformer: TreeUITransformer, config: SchemaParserConfig) => React.ReactNode;
+export interface NodeHandler {
+    render: (schemaNode: NodeSchema, node: Node, parentNode: Node, config: SchemaParserConfig) => React.ReactNode;
+    resolveInitialState?: (schemaNode: NodeSchema, node: Node, parentNode: Node, config: SchemaParserConfig, resolve: SchemaTreeResolver) => NodeState;
+    resolveChildren?: (schemaNode: NodeSchema, node: Node, parentNode: Node, config: SchemaParserConfig, resolve: SchemaTreeResolver) => Array<Node>;
+    getOutput?: (schemaNode: NodeSchema, node: Node, parentNode: Node, config: SchemaParserConfig, resolve: SchemaTreeResolver) => NodeOutputValue;
 }
 
-export interface SchemaRenderersMappingForType {
-    [key: string]: SchemaRenderer;
+export interface SchemaNodeHandlersMappingForType {
+    [key: string]: NodeHandler;
 }
 
 type NodeTypeNames = keyof typeof NodeType;
 
-export type SchemaRenderersMapping = {
-    [key in NodeTypeNames]: SchemaRenderersMappingForType;
+export type SchemaNodeHandlersMapping = {
+    [key in NodeTypeNames]: SchemaNodeHandlersMappingForType;
 };
 
 export interface SchemaParserConfig {
-     renderers: SchemaRenderersMapping;
+    handlers: SchemaNodeHandlersMapping;
+    rootState: NodeState;
+    rootSetState?: (state: NodeState, root: Node) => void;
 }
 
-export type TreeUITransformer = (NodeSchema, SchemaParserConfig) => React.ReactNode;
+export interface SchemaParserConfigOpt {
+    handlers?: SchemaNodeHandlersMapping;
+    rootState?: NodeState;
+    rootSetState?: (state: NodeState, root: Node) => void;
+}
+
+export type NodeState = any;
+
+export type NodeOutputValue = any;
+
+export type SchemaTreeResolver = (node: NodeSchema, parentNode: Node, config: SchemaParserConfig) => Node;
+
+export interface Node {
+    state: NodeState;
+    tag?: string;
+    type: NodeType;
+    schemaNode: NodeSchema;
+    children: Array<Node>;
+    handler: NodeHandler;
+    render: () => React.ReactNode;
+    getOutput: () => NodeOutputValue;
+    setState: (state: NodeState) => void;
+    findChild: (tag: string) => Node;
+}

--- a/frontend/src/components/universal/Form/schemaTypes.tsx
+++ b/frontend/src/components/universal/Form/schemaTypes.tsx
@@ -38,15 +38,26 @@ export type NodeSchema = ValueOf<NodeTypeSchemas>;
 
 export type Schema = NodeObjectSchema;
 
-export interface NodeHandler<
+export abstract class NodeHandler<
   S, O, M extends NodeSchema,
   CS = any, CO = any, CM extends NodeSchema = any,
   PS = any, PO = any, PM extends NodeSchema = any
 > {
-    render: (schemaNode: M, node: Node<S, O, M>, parentNode: Node<PS, PO, PM>, config: SchemaParserConfig) => React.ReactNode;
-    resolveInitialState?: (schemaNode: M, node: Node<S, O, M>, parentNode: Node<PS, PO, PM>, config: SchemaParserConfig, resolve: SchemaTreeResolver) => NodeState<S>;
-    resolveChildren?: (schemaNode: M, node: Node<S, O, M>, parentNode: Node<PS, PO, PM>, config: SchemaParserConfig, resolve: SchemaTreeResolver) => Array<Node<CS, CO, CM>>;
-    getOutput?: (schemaNode: M, node: Node<S, O, M>, parentNode: Node<PS, PO, PM>, config: SchemaParserConfig, resolve: SchemaTreeResolver) => NodeOutputValue<O>;
+    constructor() {}
+
+    abstract render(schemaNode: M, node: Node<S, O, M>, parentNode: Node<PS, PO, PM>, config: SchemaParserConfig): React.ReactNode;
+
+    resolveInitialState(schemaNode: M, node: Node<S, O, M>, parentNode: Node<PS, PO, PM>, config: SchemaParserConfig, resolve: SchemaTreeResolver): NodeState<S> {
+        return null;
+    }
+
+    resolveChildren(schemaNode: M, node: Node<S, O, M>, parentNode: Node<PS, PO, PM>, config: SchemaParserConfig, resolve: SchemaTreeResolver): Array<Node<CS, CO, CM>> {
+        return [];
+    }
+
+    getOutput(schemaNode: M, node: Node<S, O, M>, parentNode: Node<PS, PO, PM>, config: SchemaParserConfig, resolve: SchemaTreeResolver): NodeOutputValue<O> {
+        return null;
+    }
 }
 
 export interface SchemaNodeHandlersMappingForType<M extends NodeSchema> {

--- a/frontend/src/components/universal/Form/simpleNodes.tsx
+++ b/frontend/src/components/universal/Form/simpleNodes.tsx
@@ -1,0 +1,28 @@
+import * as React from "react";
+
+import {
+    Node,
+    NodeAny,
+    NodeHandler,
+    NodeSchema,
+    SchemaParserConfig,
+} from "./schemaTypes";
+
+export abstract class SimpleNodeHandler<V, M extends NodeSchema> extends NodeHandler<{ value: V }, V, M> {
+    abstract getInitialValue(schemaNode: M, node: Node<{ value: V }, V, M>, parentNode: NodeAny, config: SchemaParserConfig): V;
+    abstract renderSimple(schemaNode: M, value: V, node: Node<{ value: V }, V, M>, parentNode: NodeAny, config: SchemaParserConfig): React.ReactNode;
+
+    resolveInitialState(schemaNode: M, node: Node<{ value: V }, V, M>, parentNode: NodeAny, config: SchemaParserConfig) {
+        return {
+            value: this.getInitialValue(schemaNode, node, parentNode, config),
+        };
+    }
+
+    getOutput(schemaNode: M, node: Node<{ value: V }, V, M>) {
+        return node.state.value;
+    }
+
+    render(schemaNode: M, node: Node<{ value: V }, V, M>, parentNode: NodeAny, config: SchemaParserConfig) {
+        return this.renderSimple(schemaNode, node.state.value, node, parentNode, config);
+    }
+}


### PR DESCRIPTION
This is some bigger PR that improves code responsible for managing forms.

# Introduction

There are libraries like [https://github.com/mozilla-services/react-jsonschema-form](react-jsonschema-form) but are really hard to customize when it comes to advanced features like custom validation that do not conform UI model introduced by the library. The components are hard to stylize and you can add own which is a case when you do not use most of the library built-ins and try to work around its concepts.

# Why we need this code?

This enables us to quickly create UI for given data schema with type safety and optionally adds the ability to easily configure the product later (by using JSON configurations for example).

# How does it work?

The forms were based on the concept that you have the function `(model: Model<?>) => React.ReactNode` that generates UI from the abstract data model. This concept is too primitive for features like auto-validation or global state management for the entire form.

That's why this PR:
* Changes the primitive render approach to management of entire form tree
* Adds better typings support for data models with a lot of generics

This is example data schema we want to render the form with:
```
const schema: Schema = {
    title: "A registration form",
    description: "The description",
    type: NodeType.OBJECT,
    properties: {
        "firstName": {
            type: NodeType.STRING,
            title: "Your first name",
        },
        "lastName": {
            type: NodeType.STRING,
            title: "Your last name",
        },
    },
};
```
There exists a set of predefined handlers (classes that extend `NodeHandler<...>` generic). The handler is selected using the type field inside data model and using `ui` (if it's not available we choose `.default`) field in the data model.

The handler is responsible for i.e generating the initial node state, rendering the React nodes and generating a list of children nodes.

The node state is local state of the node (like React state) and there are also outputs. The output is a value generated by the node that will be visible to the form component as a value of all of the form's fields.

This PR adds also helpers to make the code cleaner.
Adding new resolver for any field (of the composite type like objects or arrays or primitives like strings or numbers - see `ObjectDefault.tsx` and `StringDefault.tsx`) is trivial and all of the types are checked and known.

# Example

For data model:
```
const schema: Schema = {
    title: "A registration form",
    description: "The description",
    type: NodeType.OBJECT,
    properties: {
        "firstName": {
            type: NodeType.STRING,
            title: "Your first name",
        },
        "lastName": {
            type: NodeType.STRING,
            title: "Your last name",
        },
    },
};
```

The UI is rendered as follows:
![image](https://user-images.githubusercontent.com/7319352/54441632-74394c00-473d-11e9-845d-be21c3bccf02.png)

And on each change the output (see type `NodeOutputValue`) is in the format:

```
{
  "firstName": "dhrhtr",
  "lastName": "rty"
}
```

With the advance versus [https://github.com/mozilla-services/react-jsonschema-form](react-jsonschema-form) that we can easily **add any renderer** for objects, arrays and easily manipulate tree as we want without reading complex documentation and we are not limited by the approach. *The model does not limit the structure of the data model except the fact that roots must contain type field.* 

# Other changes

In this PR minor code structure changes were also implemented:
* `compositeNode.ts` utility handler for nodes that are containers for other nodes
* `simpleNodes.ts` utility handler for nodes that return only single primitive value