### PR TITLE
Allow users to request limit increases

### DIFF
--- a/frontend/configs/webpack/common.js
+++ b/frontend/configs/webpack/common.js
@@ -15,6 +15,7 @@ module.exports = {
     extensions: ['.ts', '.tsx', '.js', '.jsx', 'index.ts', 'index.tsx', 'index.js', 'index.jsx'],
     alias: {
       'scss': path.join(__dirname, '..', '..', 'src', 'scss'),
+      'client': path.join(__dirname, '..', '..', 'src', 'client'),
       'components': path.join(__dirname, '..', '..', 'src', 'components', 'universal'),
       'pages': path.join(__dirname, '..', '..', 'src', 'components', 'pages'),
       'langs': path.join(__dirname, '..', '..', 'src', 'langs'),

--- a/frontend/src/client/CachedClient.ts
+++ b/frontend/src/client/CachedClient.ts
@@ -69,6 +69,10 @@ export class OmigostCachedClient implements OmigostClientInterface {
         return this.cache.transform("getBudgets", this.client.getBudgets)();
     }
 
+    postBudgetIncreaseLimit(formContext, data): ResponsePromise {
+        return this.client.postBudgetIncreaseLimit(formContext, data);
+    }
+
     callEndpoint(endpoint, options): ResponsePromise {
         return this.cache.transform(`callEndpoint(${endpoint}:${JSON.stringify(options)})`, () => this.client.callEndpoint(endpoint, options))();
     }

--- a/frontend/src/client/FakeClient.ts
+++ b/frontend/src/client/FakeClient.ts
@@ -1,5 +1,6 @@
 
 import ClientComponentFactory, { ClientAbstractComponent } from "./ClientComponentFactory";
+import {callFormEndpoint} from "./formHelpers";
 import {
     OmigostClientInterface,
     ResponseData,
@@ -32,6 +33,20 @@ export class OmigostFakeClient implements OmigostClientInterface {
             }
             resolve(budgets);
         });
+    }
+
+    postBudgetIncreaseLimit(formContext, data): ResponsePromise {
+        const fakeRequest = new Promise<ResponseData>((resolve, reject) => {
+            return setTimeout(() => {
+                if (data.reason === "TEST") return reject(new TypeError("the reason was rejected by backend"));
+                const FAILURE_CHANCE = 0.2;
+
+                const hasFailed = Math.random() < FAILURE_CHANCE;
+                if (hasFailed) return reject("something went amiss, try again");
+                return resolve("success!");
+            }, 600);
+        });
+        return callFormEndpoint(() => fakeRequest, formContext, data);
     }
 
     callEndpoint(endpoint, options): ResponsePromise {

--- a/frontend/src/client/FakeClient.ts
+++ b/frontend/src/client/FakeClient.ts
@@ -1,11 +1,11 @@
 
 import ClientComponentFactory, { ClientAbstractComponent } from "./ClientComponentFactory";
-import {callFormEndpoint} from "./formHelpers";
 import {
     OmigostClientInterface,
     ResponseData,
     ResponsePromise,
 } from "./OmigostClient";
+import {callFormEndpoint} from "./formHelpers";
 
 import fakeBudget from "./fakes/budget";
 

--- a/frontend/src/client/OmigostClient.ts
+++ b/frontend/src/client/OmigostClient.ts
@@ -3,6 +3,7 @@ import axios from "axios";
 import ClientComponentFactory, { ClientAbstractComponent } from "./ClientComponentFactory";
 import OmigostFakeClient from "./FakeClient";
 import CLIENT_URLS from "./clientUrls";
+import {callFormEndpoint, FormComponentContext} from "./formHelpers";
 
 export enum RequestMethod {
     GET = "get",
@@ -13,6 +14,8 @@ export type ResponseData = any;
 
 export type ResponsePromise = Promise<ResponseData>;
 
+export type PostBudgetIncreaseLimitPayload = {reason: string, token: string};
+
 export interface RequestOptions {
     endpoint?: string;
     params?: any;
@@ -22,6 +25,7 @@ export interface RequestOptions {
 export interface OmigostClientInterface {
     callEndpoint(endpoint?: string, options?: RequestOptions): Promise<ResponseData>;
     getBudgets(): ResponsePromise;
+    postBudgetIncreaseLimit(formContext: FormComponentContext, data: PostBudgetIncreaseLimitPayload): ResponsePromise;
     createBudget(data: any): ResponsePromise;
 }
 
@@ -40,7 +44,15 @@ export class OmigostClient implements OmigostClientInterface {
     }
 
     getBudgets(): ResponsePromise {
-        return this.callEndpoint(null, CLIENT_URLS.getBudgets);
+        return this.callEndpoint(CLIENT_URLS.getBudgets.endpoint, null);
+    }
+
+    postBudgetIncreaseLimit(formContext, data): ResponsePromise {
+        return this.submitForm(formContext, { ...CLIENT_URLS.postBudgetIncreaseLimit, data });
+    }
+
+    submitForm(formContext, options) {
+        return callFormEndpoint(this.callEndpoint.bind(this), formContext, options);
     }
 
     callEndpoint(endpoint, options): ResponsePromise {

--- a/frontend/src/client/clientUrls.ts
+++ b/frontend/src/client/clientUrls.ts
@@ -7,4 +7,8 @@ export default {
         endpoint: "budgets/create",
         method: "post",
     },
+    postBudgetIncreaseLimit: {
+        endpoint: "alerts/requestLimitIncrease",
+        method: "post",
+    },
 };

--- a/frontend/src/client/formHelpers.ts
+++ b/frontend/src/client/formHelpers.ts
@@ -1,0 +1,33 @@
+import * as React from "react";
+import {ResponsePromise} from "./OmigostClient";
+
+export enum REQUEST_STATES {
+    READY,
+    IN_PROGRESS,
+    SUCCESS,
+    ERROR,
+}
+
+export type FormState = {
+    requestState: REQUEST_STATES,
+    error: string,
+};
+
+export type FormComponentContext = React.Component<any, FormState>;
+
+
+export function callFormEndpoint(callEndpoint: (endpoint, options) => ResponsePromise, formContext: FormComponentContext, options): ResponsePromise {
+    return handleFormSubmission(
+        formContext,
+        () => callEndpoint(null, options),
+    );
+}
+
+function handleFormSubmission(formContext: FormComponentContext, request: () => ResponsePromise): ResponsePromise {
+    formContext.setState({requestState: REQUEST_STATES.IN_PROGRESS});
+
+    return request()
+        .then(() => formContext.setState({requestState: REQUEST_STATES.SUCCESS}))
+        .catch(err => formContext.setState({requestState: REQUEST_STATES.ERROR, error: err.toString()}));
+
+}

--- a/frontend/src/components/pages/BudgetLimitRequestPage/RequestLimitsForm.tsx
+++ b/frontend/src/components/pages/BudgetLimitRequestPage/RequestLimitsForm.tsx
@@ -1,0 +1,105 @@
+import * as React from "react";
+import styled from "styled-components";
+import client from "../../../client/OmigostClient";
+import {REQUEST_STATES} from "../../../client/formHelpers";
+
+
+const Header = styled.header`
+  height: auto;
+`;
+const Wrapper = styled.div``;
+const Textarea = styled.textarea`display: block;`;
+const Label = styled.label`display: block;`;
+const Submit = styled.button`display: block;`;
+const ErrorDisplay = styled.div`color: #d12;`;
+
+type RequestLimitsFormProps = {};
+type RequestLimitsFormState = {reason: string, requestState: REQUEST_STATES, error: string};
+
+
+
+export default class RequestLimitsForm extends React.Component<RequestLimitsFormProps, RequestLimitsFormState> {
+    constructor (props) {
+        super(props);
+
+        new URLSearchParams(window.location.search).get("token");
+
+        this.state = {
+            reason: "",
+            requestState: REQUEST_STATES.READY,
+            error: "",
+        };
+    }
+
+    handleChange(value: string): void {
+        return this.setState({reason: value});
+    }
+
+    failWith(reason: string): void {
+        this.setState({requestState: REQUEST_STATES.READY, error: reason});
+    }
+
+    handleSubmit = (ev) => {
+        ev.preventDefault();
+        const urlparams = new URLSearchParams(window.location.search); // TODO add polyfill?
+        const reason = this.state.reason, token = urlparams.get("token");
+        if (!reason) return this.failWith("Reason cannot be empty");
+        if (!token) return this.failWith("This address doesn't have a valid request token");
+
+        const payload = { reason, token };
+        client.postBudgetIncreaseLimit(this, payload);
+    }
+
+    form(): React.ReactNode {
+        return (
+            <Wrapper>
+                <Header>
+                    <h1>
+                        Request Budget Increase Limit
+                    </h1>
+                </Header>
+
+                <article>
+                    <form onSubmit={this.handleSubmit}>
+                        <Label htmlFor="reason">Reasons For Increasing The Limit:</Label>
+                        <Textarea id="reason" onChange={e => this.handleChange(e.target.value)} value={this.state.reason}/>
+                        <Submit type="submit">
+                            Submit
+                        </Submit>
+                    </form>
+
+                    <ErrorDisplay>
+                        {this.state.error}
+                    </ErrorDisplay>
+                </article>
+            </Wrapper>
+        );
+    }
+
+    spinner(): React.ReactNode {
+        return (
+            <article>
+                Sending...
+            </article>
+        );
+    }
+
+    success(): React.ReactNode {
+        return (
+            <article>
+                Request was successfully submitted!
+            </article>
+        );
+    }
+
+    render() {
+        switch (this.state.requestState) {
+            case REQUEST_STATES.SUCCESS:
+                return this.success();
+            case REQUEST_STATES.IN_PROGRESS:
+                return this.spinner();
+            default:
+                return this.form();
+        }
+    }
+}

--- a/frontend/src/components/pages/BudgetLimitRequestPage/index.tsx
+++ b/frontend/src/components/pages/BudgetLimitRequestPage/index.tsx
@@ -1,0 +1,21 @@
+import * as React from "react";
+import defaultTheme from "themes/default";
+
+import Page from "components/Page";
+import RequestLimitsForm from "pages/BudgetLimitRequestPage/RequestLimitsForm";
+import {ThemeProvider} from "styled-components";
+
+export interface BudgetLimitRequestPageProps {
+}
+
+export default class RequestLimitsPage extends React.Component<BudgetLimitRequestPageProps, undefined> {
+    render() {
+        return (
+            <ThemeProvider theme={defaultTheme}>
+                <Page type="fill">
+                    <RequestLimitsForm />
+                </Page>
+            </ThemeProvider>
+        );
+    }
+}

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 
 import { Route } from "react-router-dom";
 
+import RequestLimitsPage from "pages/BudgetLimitRequestPage";
 import DashboardPage from "pages/Dashboard";
 import LoadingPage from "pages/Loading";
 import LoginPage from "pages/Login";
@@ -12,6 +13,7 @@ const ROUTES = {
     "/home": DashboardPage,
     "/login": LoginPage,
     "/loading": LoadingPage,
+    "/requestBudgetLimit": RequestLimitsPage,
     "/": LoginPage,
 };
 

--- a/frontend/src/themes/default.ts
+++ b/frontend/src/themes/default.ts
@@ -13,11 +13,11 @@ export default {
     lightAccent: "white",
   },
   fontSize: {
-    S: "0.7vw",
-    default: "1vw",
-    M: "1.2vw",
-    L: "1.5vw",
-    XL: "2vw",
-    XXL: "3vw",
+    S: "9px",
+    default: "12px",
+    M: "14px",
+    L: "18px",
+    XL: "26px",
+    XXL: "34px",
   },
 };

--- a/server/src/main/java/com/omigost/server/notification/MainNotificationService.java
+++ b/server/src/main/java/com/omigost/server/notification/MainNotificationService.java
@@ -39,7 +39,7 @@ public class MainNotificationService {
     }
 
     public NotificationMessage budgetTriggeredMessage(Budget budget, String tokenString) {
-        String respondLinkUrl = "/alerts/trigger?token=" + tokenString; // TODO add host domain
+        String respondLinkUrl = "/requestBudgetLimit?token=" + tokenString; // TODO add host domain
 
         if (new BudgetDecorator(budget).isOverrun())
             return budgetOverrunMessage(budget, respondLinkUrl);

--- a/server/src/main/java/com/omigost/server/rest/AlertsController.java
+++ b/server/src/main/java/com/omigost/server/rest/AlertsController.java
@@ -5,6 +5,7 @@ import com.omigost.server.alerts.AlertService;
 import com.omigost.server.aws.BudgetService;
 import com.omigost.server.model.AlertResponseToken;
 import com.omigost.server.notification.MainNotificationService;
+import com.omigost.server.rest.dto.RequestLimitIncreaseRequest;
 import com.omigost.server.rest.dto.SubscriptionConfirmationRequest;
 import com.omigost.server.rest.exception.BudgetNotFound;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,9 +25,9 @@ public class AlertsController {
     private MainNotificationService notifications;
 
     @PostMapping("/requestLimitIncrease")
-    public void handleLimitIncreaseRequest(@RequestParam String requestBody, @RequestParam String tokenString) {
-        AlertResponseToken token = alerts.invalidateResponseToken(tokenString);
-        notifications.requestLimitIncrease(requestBody, token);
+    public void handleLimitIncreaseRequest(@RequestBody RequestLimitIncreaseRequest body) {
+        AlertResponseToken token = alerts.invalidateResponseToken(body.getToken());
+        notifications.requestLimitIncrease(body.getReason(), token);
     }
 
     @PostMapping("/trigger")

--- a/server/src/main/java/com/omigost/server/rest/dto/RequestLimitIncreaseRequest.java
+++ b/server/src/main/java/com/omigost/server/rest/dto/RequestLimitIncreaseRequest.java
@@ -1,0 +1,9 @@
+package com.omigost.server.rest.dto;
+
+import lombok.Data;
+
+@Data
+public class RequestLimitIncreaseRequest {
+    String reason;
+    String token;
+}


### PR DESCRIPTION
Styling has been lame for this so far - @styczynski I'd be glad to hear some tips on how to manage styling in a better way than defining it manually componentwise like here in the inputs for example

PS @styczynski any contraindications to removing the OmigostCachedClient completely? Browsers have a better implementation on caching that depends on response headers - this way backend can dynamically control caching per each resource

Closes #99 